### PR TITLE
Corrections to example data

### DIFF
--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -603,7 +603,7 @@ Example consent string field values for the case:
     <td>SingleVendorId[0]</td>
     <td>9</td>
     <td>VendorId=9 has No Consent (opposite of Default Consent)</td>
-    <td>00000000000001001</td>
+    <td>0000000000001001</td>
   </tr>
   <tr>
     <td>base64url-encoded consent string value</td>

--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -609,7 +609,7 @@ Example consent string field values for the case:
     <td>base64url-encoded consent string value</td>
     <td></td>
     <td></td>
-    <td>BOEFEAyOEFEAyAHABDENAI4AAAB9vABAAS</td>
+    <td>BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA</td>
   </tr>
 </table>
 

--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -524,12 +524,12 @@ Example consent string field values for the case:
   <tr>
     <td>Created </td>
     <td>15100811449 </td>
-    <td>2017-11-07T18:59:04.9Z</td>
+    <td>2017-11-07T19:15:55.4Z</td>
     <td>001110000100000101000100000000110010</td>
   </tr>
   <tr>
     <td>LastUpdated</td>
-    <td>15100811449</td>
+    <td>15100821554</td>
     <td>2017-11-07T18:59:04.9Z</td>
     <td>001110000100000101000100000000110010</td>
   </tr>

--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -387,7 +387,7 @@ user?s consent action timing. Javascript: Math.round((new Date()).getTime()/100)
     <td>12 bits
 (108-119)</td>
     <td>Two-letter ISO639-1 language code that CMP asked for consent in</td>
-    <td>Each letter should be encoded as 6 bits, a=0..z=25 . This will result in the base64url-encoded bytes spelling out the language code (in uppercase).</td>
+    <td>Each letter should be encoded as 6 bits, A=0..Z=25 . This will result in the base64url-encoded bytes spelling out the language code (in uppercase).</td>
   </tr>
   <tr>
     <td>VendorListVersion</td>
@@ -553,7 +553,7 @@ Example consent string field values for the case:
   </tr>
   <tr>
     <td>ConsentLanguage</td>
-    <td>"en" (e=4, n=13)</td>
+    <td>"EN" (E=4, N=13)</td>
     <td>Two-letter ISO639-1 language code that CMP asked for consent in</td>
     <td>000100 001101</td>
   </tr>
@@ -609,7 +609,7 @@ Example consent string field values for the case:
     <td>base64url-encoded consent string value</td>
     <td></td>
     <td></td>
-    <td>BOJObISOJObISAABAAENAA4AAAAAoAAA</td>
+    <td>BOEFEAyOEFEAyAHABDENAI4AAAB9vABAAS</td>
   </tr>
 </table>
 

--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -523,14 +523,14 @@ Example consent string field values for the case:
   </tr>
   <tr>
     <td>Created </td>
-    <td>15100811449 </td>
+    <td>15100821554 </td>
     <td>2017-11-07T19:15:55.4Z</td>
     <td>001110000100000101000100000000110010</td>
   </tr>
   <tr>
     <td>LastUpdated</td>
     <td>15100821554</td>
-    <td>2017-11-07T18:59:04.9Z</td>
+    <td>2017-11-07T19:15:55.4Z</td>
     <td>001110000100000101000100000000110010</td>
   </tr>
   <tr>


### PR DESCRIPTION
1. The stated timestamp and binary representation did not match.
2. The example consent string did not match the preceding table.
3. The sections on Language reference uppercase and give an example in lowercase.