### PR TITLE
Added LR Golang Implementation of Vendor Consent String Spec

### DIFF
--- a/Consent String SDK/README.md
+++ b/Consent String SDK/README.md
@@ -8,6 +8,8 @@
 
 [Consent String SDK - C](https://github.com/InteractiveAdvertisingBureau/Consent-String-SDK-C)
 
+[Consent String SDK - Golang](https://github.com/LiveRamp/iabconsent)
+
 Encode and decode web-safe base64 consent information with the IAB EU's GDPR Transparency and Consent Framework.
 
 Reference implementations for dealing with consent strings in the IAB EU's GDPR Transparency and Consent Framework.  


### PR DESCRIPTION
We implemented a Golang version of the Vendor Consent String Spec.