### PR TITLE
Cleanup third party SDK section

### DIFF
--- a/Consent String SDK/README.md
+++ b/Consent String SDK/README.md
@@ -22,8 +22,7 @@ The IAB specification for the consent string format is available on the [IAB Git
 
 These implementations are not supported by the IAB.
 
-- [Consent String SDK - Golang](https://github.com/LiveRamp/iabconsent)
-- [Go](https://github.com/prebid/go-gdpr)
-- [Go](https://github.com/LiveRamp/iabconsent)
-- [Rust](https://github.com/cirla/gdpr_consent)
+- [Go](https://github.com/prebid/go-gdpr) (prebid/go-gdpr)
+- [Go](https://github.com/LiveRamp/iabconsent) (LiveRamp/iabconsent)
+- [Rust](https://github.com/cirla/gdpr_consent) (cirla/gdpr_consent)
 


### PR DESCRIPTION
1. Remove duplicate link
2. Make origins clear and visible when there is more than one implementation for a given language.