### PR TITLE
Add reference to vendorinfo.json

### DIFF
--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -152,6 +152,27 @@ The vendor list will be in JSON and hosted at [https://vendorlist.consensu.org/v
 
 Translations of the standard purposes' names and descriptions to non-English languages will be contained in a JSON file including only the 'purposes', 'features', 'vendorListVersion', and 'lastUpdated' keys, and hosted at [https://vendorlist.](https://vendorlist.consensu.org/purposes-language.json)[consensu.org](https://vendorlist.consensu.org/purposes-language.json)[/purposes-](https://vendorlist.consensu.org/purposes-language.json)[*language*](https://vendorlist.consensu.org/purposes-language.json)[.json](https://vendorlist.consensu.org/purposes-language.json) with older versions at [https://vendorlist.consensu.org/v-](https://vendorlist.consensu.org/purposes-language-versionnum.json)*[versionnum*/](https://vendorlist.consensu.org/purposes-language-versionnum.json)[purposes-](https://vendorlist.consensu.org/purposes-language-versionnum.json)[*language*](https://vendorlist.consensu.org/purposes-language-versionnum.json)[.json](https://vendorlist.consensu.org/purposes-language-versionnum.json) where *language* is the two-letter lowercase ISO 639-1 language code.
 
+## What is the URL for Vendor Info (ad serving and asset domains for vendors in the GVL)?
+The Vendor Info file will be in JSON and hosted at [https://vendorlist.consensu.org/vendorinfo.json](https://vendorlist.consensu.org/vendorinfo.json).
+
+
+In this file, the use of the term "AdServers" is representative of the type of domains associated with a vendor that would be used in delivery of assets or script on page, including (but not limited to) ad serving domains.
+
+## What is the format for Vendor Info JSON File?
+```
+{
+	"vendorListVersion": 36,
+	"lastUpdated": "2018-05-30T16:10:05Z",
+	"vendors": [
+ {
+		"id": 1,
+		"name": "Example Company",
+		"AdServers": ["example.company.com (Description, Ad server and tracker)", 
+  }
+  .... and so on for each vendor included in the Global Vendor List
+}
+```
+
 ## What is the process of getting on the global vendor list? <a name="process-vendorlist"></a>
 
 Access [http://advertisingconsent.eu/](http://advertisingconsent.eu/) to register on the global vendor list. Registration guidelines are available on this website as well.


### PR DESCRIPTION
vendorinfo.json contains list of company's domains that deliver assets or run scripts (including ad serving domains)