### PR TITLE
Correct path for registered CMPs

### DIFF
--- a/v1.1 Implementation Guidelines.md
+++ b/v1.1 Implementation Guidelines.md
@@ -33,7 +33,7 @@ a. Matches the technical specifications outlined in CMP JS API v1.1
 b. Register as a CMP with IAB Europe. To register,[submit this form](https://register.consensu.org/CMP).
 
 
-2.Implement a CMP on the[ registered list](http://advertisingconsent.eu/iab-europe-transparency-consent-framework-list-of-registered-cmps/).  
+2.Implement a CMP on the[ registered list](http://advertisingconsent.eu/cmp-list/).  
 
 In the event you already have a CMP implemented and the company is not found on the IAB Europe?s registered list, it is the publisher?s responsibility to work with their provider to meet the criteria outlined in Option 1?s sub-bullets. Provided below is template language to help communication efforts with your preferred cookie consent vendor.
 


### PR DESCRIPTION
The existing URL for CMPs 404s. This is the best link I can find.