### PR TITLE
Changing specs to add missing header consentLanguage to metadata from…

### DIFF
--- a/CMP JS API v1.1 Final.md
+++ b/CMP JS API v1.1 Final.md
@@ -250,9 +250,11 @@ where *vendorId* and *purposeId* are the keys and *consentBoolean *are the value
 
 6. Consent Screen
 
-7. Vendor List Version
+7. Consent Language
 
-8. Publisher Purposes Version (for the *PublisherConsent* metadata only)
+8. Vendor List Version
+
+9. Publisher Purposes Version (for the *PublisherConsent* metadata only)
 
 ### VendorConsentData <a name="vendorconsentdata"></a>
 


### PR DESCRIPTION
Adding missing header consentLanguage to metadata from getVendorConsents method.

ConsentLanguage header present in the consentData as per consentData specs (https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md) was missing from the metadata field present in response from getVendorConsents method.
To be more coherent across the specs, this value should also be present in the metadata field from the getVendorConsents result.