### PR TITLE
Encoding warning

### DIFF
--- a/CMP JS API v1.1 Final.md
+++ b/CMP JS API v1.1 Final.md
@@ -254,9 +254,13 @@ where *vendorId* and *purposeId* are the keys and *consentBoolean *are the value
 
 8. Publisher Purposes Version (for the *PublisherConsent* metadata only)
 
+CAUTION: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+         Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 ### VendorConsentData <a name="vendorconsentdata"></a>
 
 This object contains the entire [base64url-encoded](https://tools.ietf.org/html/rfc4648#section-5) string of the vendor consent data:
+CAUTION: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+         Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 
 ```
 {

--- a/CMP JS API v1.1 Final.md
+++ b/CMP JS API v1.1 Final.md
@@ -259,6 +259,7 @@ CAUTION: This is not a base64 encoding, but a base64url encoding, which is sligh
 ### VendorConsentData <a name="vendorconsentdata"></a>
 
 This object contains the entire [base64url-encoded](https://tools.ietf.org/html/rfc4648#section-5) string of the vendor consent data:
+
 CAUTION: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
          Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 

--- a/CMP JS API v1.1 Final.md
+++ b/CMP JS API v1.1 Final.md
@@ -254,13 +254,13 @@ where *vendorId* and *purposeId* are the keys and *consentBoolean *are the value
 
 8. Publisher Purposes Version (for the *PublisherConsent* metadata only)
 
-*CAUTION*: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+**CAUTION**: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
          Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 ### VendorConsentData <a name="vendorconsentdata"></a>
 
 This object contains the entire [base64url-encoded](https://tools.ietf.org/html/rfc4648#section-5) string of the vendor consent data:
 
-*CAUTION*: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+**CAUTION**: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
          Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 
 ```

--- a/CMP JS API v1.1 Final.md
+++ b/CMP JS API v1.1 Final.md
@@ -254,13 +254,13 @@ where *vendorId* and *purposeId* are the keys and *consentBoolean *are the value
 
 8. Publisher Purposes Version (for the *PublisherConsent* metadata only)
 
-CAUTION: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+*CAUTION*: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
          Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 ### VendorConsentData <a name="vendorconsentdata"></a>
 
 This object contains the entire [base64url-encoded](https://tools.ietf.org/html/rfc4648#section-5) string of the vendor consent data:
 
-CAUTION: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
+*CAUTION*: This is not a base64 encoding, but a base64url encoding, which is slightly different. Please refers to the link above for clarification.
          Also, the string of the vendor consent data must be treated as a bytes string, not a character string
 
 ```


### PR DESCRIPTION
Adding warning regarding encoding in base64url for consent string as currently lot of confusion due to people trying to convert the consentString from a **character string** to a **base64** encoding instead of a **bytes string** to a **base64url** encoding resulting in inconsistent behavior