### PR TITLE
Spec does not match what is actually being done

### DIFF
--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -239,8 +239,8 @@ Features are informational and should be shown on the UI as a data use by that v
   </tr>
   <tr>
     <td>2</td>
-    <td>Personalisation</td>
-    <td>The collection and processing of information about user of a site to subsequently personalize advertising for them in other contexts, i.e. on other sites or apps, over time. Typically, the content of the site or app is used to make inferences about user interests, which inform future selections.</td>
+    <td>Ad and content personalisation</td>
+    <td>The collection and processing of information about user of a site to subsequently personalize advertising or content for them in other contexts, i.e. on other sites or apps, over time. Typically, the content of the site or app is used to make inferences about user interests, which inform future selections of advertising or content.</td>
   </tr>
   <tr>
     <td>3</td>


### PR DESCRIPTION
The spec specifies that purpose 2 is tied to "Personalisation", but the description presented in the spec does not match [what is being done in practice now](https://vendorlist.consensu.org/vendorlist.json), from [day 1 of the `vendorlist.json`](https://vendorlist.consensu.org/v-1/vendorlist.json). Indeed, the spec mentions personalisation of advertisements only, while the actual `vendorlist.json` file, which contains what will in practice be displayed to the users, says that this is for personalisation of advertisements AND content. 

Note that while this is "just" a Github issue, this file ([timestamped](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/commit/a32574941ce201708e30e78702278efe1ce6cd59)) is actually [referred to on the IAB website as the official spec](http://advertisingconsent.eu/publishers/) (see "CONSENT STRING AND GLOBAL VENDOR LIST FORMAT SPEC V1.1​"). Depending on who refers to this file and who refers to the actual `json`, this will have serious consequences on the validity of the consents traveling the ecosystem based on purpose 2.

Given that this is precisely the topic of several ongoing lawsuits against advertisers, and that long term control over this data is directly tied to significant power dynamics between the different actors (content producers vs advertisers), it is a pretty wild discrepancy to have let slip through.