### PR TITLE
Updates Reference CMP Code - uses example CMP_ID

### DIFF
--- a/reference/src/lib/init.js
+++ b/reference/src/lib/init.js
@@ -9,7 +9,11 @@ import pack from '../../package.json';
 import config from './config';
 
 const CMP_VERSION = 1;
-const CMP_ID = 1;
+
+// CMP_ID is the ID of your consent management provider according to the IAB. Get an ID here: https://advertisingconsent.eu/cmps/
+const CMP_ID = 0;
+
+// The cookie specification version, as determined by the IAB. Current is 1.
 const COOKIE_VERSION = 1;
 
 export function init(configUpdates) {
@@ -66,5 +70,3 @@ export function init(configUpdates) {
 			log.error('Failed to load CMP', err);
 		});
 }
-
-


### PR DESCRIPTION
The AppNexus reference implementation used CMP_ID=1 as an example value, expecting CMP implementations to replace the value with their own IAB-assigned CMP ID. We've updated the AppNexus implementation to now use CMP ID 0 as an example, and added a note indicating that future implementers of the code should register for a CMP ID. 

This PR brings the IAB reference code up-to-date in this regard. 

For reference, this is merged in the CMP reference implementation: 
![image](https://user-images.githubusercontent.com/5784418/49176906-e36b6b80-f319-11e8-8ba1-89221077ac5c.png). 

