### PR TITLE
Update global cookie support

### DIFF
--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -315,6 +315,11 @@ Features are informational and should be shown on the UI as a data use by that v
   </tr>
 </table>
 
+## Global Cookie Storage Update (October 2019)
+- All requests that read from or write to the global cookie in the consensu.org domain must be secured by HTTPS
+- All cookies created must have the following attributes set:
+  - SameSite=None
+  - Secure 
 
 ## Vendor Consent String Format <a name="vendor-consent-string-format"></a>
 

--- a/Consent string and vendor list formats v1.1 Final.md
+++ b/Consent string and vendor list formats v1.1 Final.md
@@ -315,11 +315,9 @@ Features are informational and should be shown on the UI as a data use by that v
   </tr>
 </table>
 
-## Global Cookie Storage Update (October 2019)
+## Global Cookie Storage Update (December 2019)
 - All requests that read from or write to the global cookie in the consensu.org domain must be secured by HTTPS
-- All cookies created must have the following attributes set:
-  - SameSite=None
-  - Secure 
+- Additionally, browser cookie policies may require the support of certain attributes (e.g. sameSite, Secure)
 
 ## Vendor Consent String Format <a name="vendor-consent-string-format"></a>
 


### PR DESCRIPTION
In order to support global cookie with current browser changes. Chrome 80, due to be launched in February 2020, requires cookie attributes 'SameSite=None' and 'Secure' to be set for 3rd party cookies to work, as well as any access to cookies to be over HTTPS.