### PR TITLE
Consistent camel-casing for Optins

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -479,7 +479,7 @@ TCData = {
 
     }
   },
-  specialFeatureOptins: {
+  specialFeatureOptIns: {
 
       /**
        * true - Special Feature Opted Into
@@ -701,7 +701,7 @@ InAppTCData = {
    * 1 - Special Feature Opted Into
    * 0 - Special Feature NOT Opted Into
    */
-  specialFeatureOptins: '01010 -- Special Feature bitfield',
+  specialFeatureOptIns: '01010 -- Special Feature bitfield',
 
   publisher: {
 


### PR DESCRIPTION
Fixing a potential type. Please ignore if this is a non-issue.

Should these be `Optins` or `OptIns`?
`IABTCF_SpecialFeaturesOptIns` uses `OptIns`.