### PR TITLE
Proposed changes in spec doc

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -262,7 +262,7 @@ The CMP will, in most cases, invoke the callback when  either the `'tcloaded'` O
 
 The callback shall be invoked with `false` as the argument for the `success` parameter if the callback could not be registered as a listener for any reason.
 
-**Note:** The `addEventListener` callback shall be immediately called upon registration with the current TC data, then subsequently called again on any TC String changes unless it is removed via `removeEventListener`.
+> **Note**: The `addEventListener` callback shall be immediately called upon registration with the current TC data, even if the CMP status is `loading` and the CMP has incomplete TC Data, so that the calling script may have access to its registered `listenerId`. Furthermore, on every TC String change the callback shall be called unless it is removed via `removeEventListener`.
 ______
 
 #### `removeEventListener`

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -262,7 +262,7 @@ The CMP will, in most cases, invoke the callback when  either the `'tcloaded'` O
 
 The callback shall be invoked with `false` as the argument for the `success` parameter if the callback could not be registered as a listener for any reason.
 
-**Note:** The `addEventListener` callback, upon registration, should be immediately called with the current TC String, then subsequently called on any TC String changes until it is removed as listeners via `removeEventListener`.
+**Note:** The `addEventListener` callback shall be immediately called upon registration with the current TC data, then subsequently called again on any TC String changes unless it is removed via `removeEventListener`.
 ______
 
 #### `removeEventListener`
@@ -374,7 +374,7 @@ TCData = {
    * undefined - unknown whether GDPR Applies
    * see the section: "What does the gdprApplies value mean?"
    */
-  gdprApplies: Boolean,
+  gdprApplies: Boolean | undefined,
 
   /*
    * see addEventListener command
@@ -559,7 +559,7 @@ PingReturn = {
    * undefined - unknown whether GDPR Applies
    * see the section: "What does the gdprApplies value mean?"
    */
-  gdprApplies: Boolean,
+  gdprApplies: Boolean | undefined,
 
   /**
    * true - CMP main script is loaded
@@ -586,25 +586,25 @@ PingReturn = {
    * CMPs own/internal version that is currently running
    * undefined if still the stub
    */
-  cmpVersion: Number,
+  cmpVersion: Number | undefined,
 
   /**
    * IAB Assigned CMP ID
    * undefined if still the stub
    */
-  cmpId: Number,
+  cmpId: Number | undefined,
 
   /**
    * Version of the GVL currently loaded by the CMP
    * undefined if still the stub
    */
-  gvlVersion: Number,
+  gvlVersion: Number | undefined,
 
   /**
    * Number of the supported TCF version
    * undefined if still the stub
    */
-  tcfPolicyVersion: Number,
+  tcfPolicyVersion: Number | undefined,
 };
 ```
 **Note:** `cmpLoaded` must be set to `true` if the main script is loaded and the stub interface is replaced, regardless of whether or not the user will see the UI or interact with it.


### PR DESCRIPTION
#### Change addEventListener/removeEventListener interface

[window.postmessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) cannot [serialize](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) a function object, so the
original spec for removeEventListener does not work cross-frame.
To handle this, let CMP maintain a internal map of registered
listeners and their IDs.

- TCData layout: add `listenerId`
- removeEventListener `parameter` param: `callback` -> `listenerId`

#### Clarify addEventListener callback invocation time

Emphasize that the callback should be invoked with the current TC
String upon registration, so that it makes sense to recommend
"calling scripts register a listener function via addEventListener
instead of getTCData" in the `getTCData` section.

#### Remove SafeFrame proxy communications.

Remove descriptions on safeFrame proxy since it is incompatible
with caller sync expectations.