### PR TITLE
Specify callId data type

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -952,7 +952,7 @@ CMPs shall create an event listener to handle `postMessage` requests via the [CM
 
 **Sent Message**
 
-The sent message shall follow the form outlined below. The command, parameter and version object properties correspond to their namesake parameters defined as method argument parameters for `__tcfapi()` method. The “sent message” also requires a unique callId property to help match the request with a response. The `callId` property can be either a string or a number, but the calling script should not use the two types interchangeably.
+The sent message shall follow the form outlined below. The command, parameter and version object properties correspond to their namesake parameters defined as method argument parameters for `__tcfapi()` method. The “sent message” also requires a unique callId property to help match the request with a response. The `callId` property shall be either a string or a number, but the calling script shall not use the two types interchangeably.
 
 ```javascript
 {

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -952,7 +952,7 @@ CMPs shall create an event listener to handle `postMessage` requests via the [CM
 
 **Sent Message**
 
-The sent message shall follow the form outlined below. The command, parameter and version object properties correspond to their namesake parameters defined as method argument parameters for `__tcfapi()` method. The “sent message” also requires a unique callId property to help match the request with a response.
+The sent message shall follow the form outlined below. The command, parameter and version object properties correspond to their namesake parameters defined as method argument parameters for `__tcfapi()` method. The “sent message” also requires a unique callId property to help match the request with a response. The `callId` property can be either a string or a number, but the calling script should not use the two types interchangeably.
 
 ```javascript
 {


### PR DESCRIPTION
This PR clarifies what data type `callId` should have.

To be consistent with `listenerId`, it should be a number, but the code snippet given in the doc implies it is a string. To be backward-compatible, it's reasonable to allow both types.

Note, however, that a calling script should choose one type and stick to it, because JS objects don't differentiate numeric keys from string keys: [MDN doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors) section "property names".