### PR TITLE
Clarify CMP hosting and caching

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -1717,6 +1717,8 @@ Given the scale of the TCF and the high volume of requests for the Global Vendor
 
 #### CMPs caching the GVL
 
+CMP code running in browsers should not fetch the GVL directly. The most current version of the GVL must be hosted and provided by each CMP, fetched by the server-side application no more often than the cache-control headers indicate.
+
 CMPs shall set [cache-control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) on HTTP responses sent to client-side requests for GVL files to prevent users from repeatedly downloading the file. When cache-control headers are set browsers will automatically cache the GVL file and return the file from cache to the client-side script running when it makes the request circumventing the need to fetch the file over HTTP again and again.
 
 


### PR DESCRIPTION
Per issue #187 clarify language for CMPs to understand requirements for hosting, fetching and caching the GVL.