### PR TITLE
Small type change in doc

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -193,7 +193,7 @@ ______
 |--:|:-:|:--|
 | command | string | `'ping'` |
 | [version](#how-does-the-version-parameter-work) | number | `2` |
-| callback | function | `function(PingReturn:object)` |
+| callback | function | `function(pingReturn: PingReturn)` |
 
 **Example:**
 


### PR DESCRIPTION
The callback in `ping` command is mis-typed, parameter is not of type `object` (well, it is in fact) but of type `PingReturn`.