### PR TITLE
Handling conflict between v1.1 strings and v2 strings

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -387,7 +387,7 @@ The following table summarises where data is stored:
 </table>
 
 #### Managing conflicting string versions
-Before 30 September 2020, [https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/](the date v1.x strings will be considered invalid), if a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
+Before 30 September 2020, [after which v1.x strings will be considered invalid](https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/), if a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 
 **Note:** TCF version 2 introduces [“Publisher Restrictions”](#what-are-publisher-restrictions), which, if exhausted by a publisher, could result in TC strings that are larger than the size limit for cookies.  While this possibility is remote, it should be guarded against – a CMP should work with a publisher to help them accomplish their goals. [Publisher Restrictions](#what-are-publisher-restrictions) are only allowed in TC Strings, therefore within a service-specific context so CMPs may need to take this into consideration when deciding on the storage mechanism for those TC Strings.
 

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -386,7 +386,7 @@ The following table summarises where data is stored:
   </tbody>
 </table>
 
-**Managing conflicting string versions:**
+#### Managing conflicting string versions
 If a CMP encounters a situation where both a v1.1 string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.1 string to ensure that there is only one source of truth for consumers of the string.
 
 **Note:** TCF version 2 introduces [“Publisher Restrictions”](#what-are-publisher-restrictions), which, if exhausted by a publisher, could result in TC strings that are larger than the size limit for cookies.  While this possibility is remote, it should be guarded against – a CMP should work with a publisher to help them accomplish their goals. [Publisher Restrictions](#what-are-publisher-restrictions) are only allowed in TC Strings, therefore within a service-specific context so CMPs may need to take this into consideration when deciding on the storage mechanism for those TC Strings.

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -385,6 +385,8 @@ The following table summarises where data is stored:
     </tr>
   </tbody>
 </table>
+**Managing conflicting string versions:**
+If a CMP encounters a situation where both a v1.1 string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.1 string to ensure that there is only one source of truth for consumers of the string.
 
 **Note:** TCF version 2 introduces [“Publisher Restrictions”](#what-are-publisher-restrictions), which, if exhausted by a publisher, could result in TC strings that are larger than the size limit for cookies.  While this possibility is remote, it should be guarded against – a CMP should work with a publisher to help them accomplish their goals. [Publisher Restrictions](#what-are-publisher-restrictions) are only allowed in TC Strings, therefore within a service-specific context so CMPs may need to take this into consideration when deciding on the storage mechanism for those TC Strings.
 

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -385,6 +385,7 @@ The following table summarises where data is stored:
     </tr>
   </tbody>
 </table>
+
 **Managing conflicting string versions:**
 If a CMP encounters a situation where both a v1.1 string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.1 string to ensure that there is only one source of truth for consumers of the string.
 

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -387,7 +387,7 @@ The following table summarises where data is stored:
 </table>
 
 #### Managing conflicting string versions
-If a CMP encounters a situation where both a v1.1 string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.1 string to ensure that there is only one source of truth for consumers of the string.
+After the transition to TCF version 2 occurs, if a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 
 **Note:** TCF version 2 introduces [“Publisher Restrictions”](#what-are-publisher-restrictions), which, if exhausted by a publisher, could result in TC strings that are larger than the size limit for cookies.  While this possibility is remote, it should be guarded against – a CMP should work with a publisher to help them accomplish their goals. [Publisher Restrictions](#what-are-publisher-restrictions) are only allowed in TC Strings, therefore within a service-specific context so CMPs may need to take this into consideration when deciding on the storage mechanism for those TC Strings.
 

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -387,7 +387,7 @@ The following table summarises where data is stored:
 </table>
 
 #### Managing conflicting string versions
-After the transition to TCF version 2 occurs, if a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
+Before 30 September 2020, [https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/](the date v1.x strings will be considered invalid), if a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 
 **Note:** TCF version 2 introduces [“Publisher Restrictions”](#what-are-publisher-restrictions), which, if exhausted by a publisher, could result in TC strings that are larger than the size limit for cookies.  While this possibility is remote, it should be guarded against – a CMP should work with a publisher to help them accomplish their goals. [Publisher Restrictions](#what-are-publisher-restrictions) are only allowed in TC Strings, therefore within a service-specific context so CMPs may need to take this into consideration when deciding on the storage mechanism for those TC Strings.
 


### PR DESCRIPTION
During a Framework Signal WG call deprecation of TCF v1.1 strings was discussed and it was agreed that help manage this process and maintain the integrity of the TC String (the WG mission) that CMPs should be asked to remove TCF v1.1 strings if a TCF v2.0 string was present. This ensures that vendors are not conflicted by presentation of two strings. Policy have have confirmed that this does not require a policy change but we feel that this does require a Tech Spec change. Patrick is off this week so I am picking this up in his absence.