### PR TITLE
Update IAB Tech Lab - CMP API v2.md

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -876,7 +876,7 @@ For performance reasons, the preferred way to make this happen in current ad ser
 | Macro | Values |
 | :-- | :-- |
 | `${GDPR}`| <p>**1** - GDPR Applies</p><p>**0** - GDPR does not apply</p><p>**unset** - unknown</p> |
-| `${GDPR_CONSENT}`| Encoded TC String |
+| `${GDPR_CONSENT_XXXX}`| Encoded TC String where XXXX is the numeric Vendor ID of the vendor receiving the TC string. |
 
 **Note**: Values align with IAB OpenRTB GDPR Advisory
 


### PR DESCRIPTION
Added missing Vendor ID to GDPR_CONSENT macro to align with "How does a URL-based service process the TC string when it can't execute JavaScript?" in the IAB Tech Lab - Consent string and vendor list formats v2 document.