### PR TITLE
Fix Typo in IAB Tech Lab - CMP API v2.md

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -1100,7 +1100,7 @@ Below is an example script that emulates the in-frame `__tcfapi()` call. It loca
 
 }());
 
-__tcfapi('ping', (pingReturn, success) => {
+__tcfapi('ping', 2, (pingReturn, success) => {
 
   // should get response from window.top's CMP
 


### PR DESCRIPTION
fixing a typo in documentation example code that left the version param out of a __tcfapi() call
fix for issue #207