### PR TITLE
Update publisher restrictions format

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -1022,7 +1022,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       <td>Purpose ID</td>
       <td>
         The Vendor’s declared Purpose ID that the publisher has indicated
-        that they are overriding.
+        that they are overriding. Use Purpose ID 63 in order to signal "all purposes".
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
added "purpose 63" (to be discussed) in order to signal that this override should apply to all purposes. an "override all" is the more common scenario but is currently requiereing 10 restriction sections for each of the 10 purposes. an "all purposes" type can reduce the length of the tc string drastically while still being very explicit in the meaning.