### PR TITLE
Deprecate cmpStatus = loading

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -615,7 +615,7 @@ PingReturn = {
 | Status Code | Applicable for | Description |
 | :-------- | :------------- | :------------- |
 | `'stub'` | cmpStatus | CMP not yet loaded – stub still in place |
-| `'loading'` | cmpStatus | CMP is loading |
+| `'loading'` | cmpStatus | DEPRECATED (this status is not distinct and will be removed in a future version) |
 | `'loaded'` | cmpStatus | CMP is finished loading |
 | `'error'` | cmpStatus | CMP is in an error state. A CMP shall not respond to any other API requests if this cmpStatus is present. A CMP may set this status if, for any reason, it is unable to perform the operations in compliance with the TCF. |
 | `'visible'` | displayStatus | User interface is currently displayed |


### PR DESCRIPTION
This status is not distinct or descriptive and is therefore considered deprecated. It will be removed in the next version.