### PR TITLE
Implement Accept All/Reject All buttons in reference implementation

### DIFF
--- a/reference/src/components/popup/intro/intro.jsx
+++ b/reference/src/components/popup/intro/intro.jsx
@@ -21,6 +21,7 @@ export default class Intro extends Component {
 
 		const {
 			onAcceptAll,
+			onRejectAll,
 			onShowPurposes,
 			onClose
 		} = props;
@@ -46,10 +47,16 @@ export default class Intro extends Component {
 						<LocalLabel localizeKey='showPurposes'>Manage your choices</LocalLabel>
 					</Button>
 					<Button
-						class={style.acceptAll}
+						class={style.choiceButton}
 						onClick={onAcceptAll}
 					>
-						<LocalLabel localizeKey='acceptAll'>Got it, thanks!</LocalLabel>
+						<LocalLabel localizeKey='acceptAll'>Accept All</LocalLabel>
+					</Button>
+					<Button
+						class={style.choiceButton}
+						onClick={onRejectAll}
+					>
+						<LocalLabel localizeKey='RejectAll'>Reject All</LocalLabel>
 					</Button>
 				</div>
 			</div>

--- a/reference/src/components/popup/intro/intro.less
+++ b/reference/src/components/popup/intro/intro.less
@@ -15,17 +15,22 @@ div.intro {
 		margin: 4% 0;
 		overflow: auto;
 	}
+
 	.options {
 		display: flex;
 		flex-shrink: 0;
 		width: 100%;
 		padding-bottom: 10px;
+
+		button {
+			margin-right: 10px;
+		}
+		div:first-child{
+			margin-left: 0;
+		}
 	}
-	.rejectAll {
-		flex: 1;
-		margin-right: 10px;
-	}
-	.acceptAll {
+
+	.choiceButton {
 		flex: 1;
 	}
 }

--- a/reference/src/components/popup/popup.jsx
+++ b/reference/src/components/popup/popup.jsx
@@ -21,6 +21,14 @@ export default class Popup extends Component {
 		onSave();
 	};
 
+	onRejectAll = () => {
+		const { store, onSave } = this.props;
+		store.selectAllVendors(false);
+		store.selectAllPurposes(false);
+		store.selectAllCustomPurposes(false);
+		onSave();
+	};
+
 	onCancel = () => {
 		this.setState({
 			selectedPanelIndex: SECTION_INTRO
@@ -57,6 +65,7 @@ export default class Popup extends Component {
 					<Panel selectedIndex={selectedPanelIndex}>
 						<Intro
 							onAcceptAll={this.onAcceptAll}
+							onRejectAll={this.onRejectAll}
 							onShowPurposes={this.handleShowDetails}
 							onClose={this.handleClose}
 						/>

--- a/reference/src/components/popup/popup.test.js
+++ b/reference/src/components/popup/popup.test.js
@@ -47,6 +47,27 @@ describe('Popup', () => {
 		popup.onAcceptAll();
 	});
 
+	it('should handle reject all', (done) => {
+		const store = new Store();
+		store.selectAllVendors = jest.fn();
+		store.selectAllPurposes = jest.fn();
+		store.selectAllCustomPurposes = jest.fn();
+
+		let popup;
+		render(<Popup
+			store={store}
+			ref={ref => popup = ref}
+			onSave={() => {
+				expect(store.selectAllVendors.mock.calls[0][0]).to.equal(false);
+				expect(store.selectAllPurposes.mock.calls[0][0]).to.equal(false);
+				expect(store.selectAllCustomPurposes.mock.calls[0][0]).to.equal(false);
+				done();
+			}}
+		/>, scratch);
+
+		popup.onRejectAll();
+	});
+
 	it('should switch between panel states', () => {
 		const store = new Store();
 


### PR DESCRIPTION
Based on the guidance provided by the ICO (UK) at
https://ico.org.uk/for-organisations/guide-to-pecr/guidance-on-the-use-of-cookies-and-similar-technologies/how-do-we-comply-with-the-cookie-rules/#comply12

> Depending on the circumstances, particularly the design of your
consent mechanism and the wording you use in the information you
provide, it is also likely that predetermining non-essential cookies
could be considered as ‘nudge behaviour’ – ie, you are influencing the
user to take a particular course of action. 

> A consent mechanism that emphasises ‘agree’ or ‘allow’ over ‘reject’
or ‘block’ represents a non-compliant approach, as the online service is
influencing users towards the ‘accept’ option.

> A consent mechanism that doesn’t allow a user to make a choice would
also be non-compliant, even where the controls are located in a ‘more
information’ section.

Also based on the guidance provided by the CNIL (FR) with an excerpt
translated below. See
https://www.cnil.fr/sites/default/files/atoms/files/recommandation-cookies-et-autres-traceurs.pdf
for the full document.

> 30. The data controller must offer users both the possibility of
accepting and refusing read and/or write operations with the same degree
of simplicity.

> 31.  The Commission therefore strongly recommends that the mechanism
for expressing a refusal to consent to read and/or write operations
should be accessible on the same screen and with the same degree of ease
as the mechanism for expressing consent. Indeed, it believes that
consent collection interfaces that require a single click to consent to
tracing while several actions are required to "set up" a refusal to
consent present, in most cases, the risk of biasing the user's choice,
who wishes to be able to view the site or use the application quickly.

> For example, at the first level of information, users may have a
choice between two buttons presented at the same level and in the same
format, with "accept all" and "refuse all", "allow" and "prohibit", or
"consent" and "do not consent", or other equivalent and sufficiently
clear wording, respectively.  The Commission considers that this
modality constitutes a simple and clear means of enabling the user to
express his refusal as easily as his consent.

> Figure 4 - The user can choose between an "accept all" and a "refuse
all" button presented at the same level and in the same format.


Screenshot of the new reference implementation with the changes made as part of this pull request:

![Screenshot of modified reference implementation](https://user-images.githubusercontent.com/3525824/99322749-894a7480-2868-11eb-8949-fa4d94b1fe20.png)
