### PR TITLE
clearly handle no cookie use

### DIFF
--- a/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
+++ b/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
@@ -67,7 +67,7 @@ The number of seconds representing the longest potential duration for cookie sto
   <tr>
    <td><code>cookieMaxAgeSeconds</code>
    </td>
-   <td><strong>optional</strong>
+   <td><strong>Required if useCookies is set to True, else optional</strong>
    </td>
    <td>integer
    </td>

--- a/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
+++ b/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
@@ -16,6 +16,37 @@ In its Planet49 judgment (available [here](http://curia.europa.eu/juris/document
 
 ## Global Vendor List Fields<sup id="a2">[2](#f2)</sup>
 
+### <code>usesCookies</code>
+
+This true or false field indicates whether the vendor uses cookie storage (session or otherwise).
+
+<table>
+  <tr>
+   <td>Field
+   </td>
+   <td>Scope
+   </td>
+   <td>Type
+   </td>
+   <td>Default
+   </td>
+   <td>Description
+   </td>
+  </tr>
+  <tr>
+   <td><code>usesCookies</code>
+   </td>
+   <td><strong>required</strong>
+   </td>
+   <td>Boolean
+   </td>
+   <td>-
+   </td>
+   <td>Indicates whether the vendor uses cookie storage (session or otherwise). True indicates cookie storage is used. False cookie storage is not used. 
+   </td>
+  </tr>
+</table>
+
 ### <code>cookieMaxAgeSeconds</code>
 
 The number of seconds representing the longest potential duration for cookie storage on a device. If a Vendor uses multiple cookies with differing durations, <code>cookieMaxAgeSeconds</code> represents the cookie with the longest duration. Note: cookies are the only method of storage or device access that permit a predictable duration to be set. 
@@ -36,7 +67,7 @@ The number of seconds representing the longest potential duration for cookie sto
   <tr>
    <td><code>cookieMaxAgeSeconds</code>
    </td>
-   <td><strong>required</strong>
+   <td><strong>optional</strong>
    </td>
    <td>integer
    </td>
@@ -73,7 +104,7 @@ This true or false field indicates whether the vendor uses other, non-cookie met
    </td>
    <td>-
    </td>
-   <td>Indicates the vendor’s use of non-cookie storage and access to information already stored on a user’s device. True indicates non-cookie access is used. False indicates only cookie storage and access are used. 
+   <td>Indicates the vendor’s use of non-cookie storage and access to information already stored on a user’s device. True indicates non-cookie access is used. False indicates non-cookie storage and access to information already stored on a user's device <em>is not</em> used. 
    </td>
   </tr>
 </table>

--- a/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
+++ b/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
@@ -67,7 +67,7 @@ The number of seconds representing the longest potential duration for cookie sto
   <tr>
    <td><code>cookieMaxAgeSeconds</code>
    </td>
-   <td><strong>Required if useCookies is set to True, else optional</strong>
+   <td><strong>required if useCookies is set to true, else optional</strong>
    </td>
    <td>integer
    </td>

--- a/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
+++ b/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
@@ -213,7 +213,7 @@ For types of mechanisms (non-cookie) where duration cannot be set, this field sh
   <tr>
    <td><code>domain</code>
    </td>
-   <td><strong>optional*</strong>
+   <td><strong>optional</strong>
    </td>
    <td>string
    </td>

--- a/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
+++ b/TCFv2/IAB Tech Lab - Device storage duration and access disclosure.md
@@ -73,7 +73,7 @@ The number of seconds representing the longest potential duration for cookie sto
    </td>
    <td>-
    </td>
-   <td>The number, in seconds, of the longest potential duration for storage on a device, as set when using the cookie method of storage. A negative number or a 0 indicate session storage similar to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">Set-Cookie</a> spec. If a vendor only uses non-cookie storage the value should not be positive.  <em>Note: this only includes what is declared when the storage is set and does not consider duration extensions should storage be refreshed. </em>
+   <td>The number, in seconds, of the longest potential duration for storage on a device, as set when using the cookie method of storage. A negative number or a 0 indicate session storage similar to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie">Set-Cookie</a> spec. A "-100" value no longer indicates no cookie usage. <em>Note: this only includes what is declared when the storage is set and does not consider duration extensions should storage be refreshed. </em>
    </td>
   </tr>
 </table>
@@ -201,7 +201,7 @@ The deviceStorage.json is hosted at the vendor-supplied URL (<code>deviceStorage
   <tr>
    <td><code>maxAgeSeconds</code>
    </td>
-   <td><strong>required</strong>
+   <td><strong>required if type = 'cookie' else null</strong>
    </td>
    <td>integer
    </td>


### PR DESCRIPTION
Currently, IAB Europe, the managing organization (MO) for TCF is using the value -100 as a proxy to indicate a GVL vendor does not use cookies of any kind (including session cookies). This pull request is meant to add a clear indication to CMPs and subsequently to users that a vendor does not use cookies of any kind.