### PR TITLE
Updated TCF specifications based on changes required for TCF v2.2

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -136,13 +136,13 @@ Secondarily, CMPs must provide a proxy for postMessage events targeted to the `_
 
 ### What required API commands must a CMP support?
 
-All CMPs must support four required API commands: [`'getTCData'`](#gettcdata), [`'ping'`](#ping), [`'addEventListener'`](#addeventlistener) and [`'removeEventListener'`](#removeeventlistener).
+All CMPs must support three required API commands: [`'ping'`](#ping), [`'addEventListener'`](#addeventlistener) and [`'removeEventListener'`](#removeeventlistener).
 
 ______
 
 #### `getTCData`
 
-Deprecated in TCF v2.1. Add an `addEventListener` and use its callback function to access the tcData object.
+Deprecated in TCF v2.1. Add an [`'addEventListener'`](#addeventlistener) and use its callback function to access the tcData object.
 
 ______
 

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -142,7 +142,7 @@ ______
 
 #### `getTCData`
 
-Deprecated in TCF v2.1. Add an [`'addEventListener'`](#addeventlistener) and use its callback function to access the tcData object.
+Deprecated in TCF v2.2. Add an [`'addEventListener'`](#addeventlistener) and use its callback function to access the tcData object.
 
 ______
 

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -2,7 +2,7 @@
 # Consent Management Platform API
 **IAB Europe Transparency & Consent Framework**
 
-**Final v.2.0 | August 2019, Updated September 2021**
+**Final v.2.1 May 2023**
 
 - [Version History](#version-history)
 - [Introduction](#introduction)
@@ -49,12 +49,14 @@
     - [Using postmessage](#using-postmessage)
     - [Is there a sample iframe script call to the CMP API?](#is-there-a-sample-iframe-script-call-to-the-cmp-api)
   - [From where will the API retrieve the TC string?](#from-where-will-the-api-retrieve-the-tc-string)
+  - [Major Changes from 2.0](#major-changes-from-20)
   - [Major Changes from 1.1](#major-changes-from-11)
 
 ## Version History
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
+| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: Deprecated API command "getTCData".
 | September 2021 | 2.0 | Deprecation of Global Scope and OOB |
 | February 2020 | 2.0 | Removed CMP List; added included in the Consent String and Vendor List Specification |
 | February 2020 | 2.0 | Updated stub example to reference open-source library, change addEventListener/removeEventListener interface, clarify addEventListener callback invocation time, and remove SafeFrame proxy communications |
@@ -118,19 +120,9 @@ This document specifies required functionality that the CMP must provide in acco
 
 ### What is the Global Vendor List?
 
-The Global Vendor List (GVL) is a technical document that CMPs download from a domain managed by IAB Europe. It lists all registered and approved Vendors, as well as standard Purposes, Features, Special Purposes, Special Features and Stacks. The information stored in the GVL is used for determining what legal disclosures must be made to the user. IAB Europe manages and publishes the GVL.
+The Global Vendor List (GVL) is a technical document that CMPs download from a domain managed by IAB Europe. It lists all registered and approved Vendors, as well as standard Purposes, Features, Special Purposes, Special Features, Stacks and Data Categories used in conjunction with purposes. The information stored in the GVL is used for determining what legal disclosures must be made to the user. IAB Europe manages and publishes the GVL.
 
-The Global Vendor List contains the following information:
-
-*   A Global Vendor List version.
-*   A list of standard Purposes, including any Special Purposes.
-*   A list of standard Features. Vendors can indicate that they use Features. Since they span purposes, users cannot exercise choice  about any of them, but Features Vendors use should be disclosed  in the CMP’s UI.
-*   A list of Special Features, which are Features for which users are given an opt-in choice.
-*   A list of Stack definitions.
-*   A list of Vendors with assigned Vendor IDs (denoted as **VendorIds** in the string), the standard Purposes for which they are requesting consent, the standard Purposes they will be using on the legitimate interest legal basis, the Features they may use across declared Purposes, and the URL of their GDPR/privacy policy page. _VendorIds_ are incrementally-assigned and not reused; deleted Vendors are just marked as deleted.
-*   Vendor GET limits to inform overflow option. This provides the information needed to support Vendor’s ability to use the http GET request.
-
-You can learn more about the Global Vendor list on the IAB EU website: [https://iabeurope.eu/tcf](https://iabeurope.eu/tcf)
+See the ‘The Global Vendor List’ section in the ‘Consent string and vendor list formats v2’ spec which describes the content and the use of the global vendor list in detail.
 
 ### How does the CMP provide the API?
 
@@ -150,40 +142,7 @@ ______
 
 #### `getTCData`
 
-| argument name | type | optional | value |
-|--:|:-:|:-:|:--|
-| command | string | | `'getTCData'` |
-| [version](#how-does-the-version-parameter-work) | number | | `2` |
-| callback | function | | `function(tcData: TCData, success: boolean)` |
-| parameter | int array | ✔️  | `vendorIds` |
-
-**Example:**
-
-```javascript
-__tcfapi('getTCData', 2, (tcData, success) => {
-
-  if(success) {
-
-    // do something with tcData
-
-  } else {
-
-    // do something else
-
-  }
-
-}, [1,2,3]);
-```
-
-The `vendorIds` array contains the integer-value Vendor IDs for Vendors in which transparency and consent is being requested.
-
-If the `vendorIds` argument is not defined the callback will be called with a [`TCData`](#tcdata) that includes Transparency and Consent values for all Vendors in the [Global Vendor List](#what-is-the-global-vendor-list).  If GDPR does not apply to this user in this context (`gdprApplies=false`) then this user will have no Transparency and Consent values and a TCData object with no Transparency and Consent values for any Vendors will be passed to the callback function. For more on `gdprApplies` see the section ["What does the gdprApplies value mean?"](#what-does-the-gdprapplies-value-mean).
-
-Once the stub `__tcfapi` function has been replaced with the final implementation, the callback shall be called immediately and without any asynchronous logic with whatever is available in the current state of the CMP.  To determine the current state the callback will need to evaluate the [`eventStatus`](#addeventlistener) property value.  It is recommended that calling scripts register a listener function via [`addEventListener`](#addeventlistener) instead of `getTCData`, which also exposes a [`TCData`](#tcdata) object, to ensure necessary TC string and decoded TC values under the right circumstances and context for their legal basis as specified in [TCF Policy](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/). The consent and legitimate interest values will be `false` in the [`TCData`](#tcdata) object for any unregistered Vendor ID passed in the vendorIds array.  Which, in accordance with [TCF Policy](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/), means “No Consent” for _consent_ and “No Legitimate Interest Transparency Established” for _legitimate interest_.
-
-A value of `false` will be passed as the argument to the `success` callback parameter if an invalid `vendorIds` argument is passed with this command. An invalid `vendorIds` argument would constitute anything other than an array of positive integers.
-
-The `callback` shall be invoked only once per api call with this command.
+Deprecated in TCF v2.1. Add an `addEventListener` and use its callback function to access the tcData object.
 
 ______
 
@@ -365,7 +324,7 @@ This object contains both the encoded and unencoded values of the TC String as w
 ``` javascript
 TCData = {
   tcString: 'base64url-encoded TC string with segments',
-  tcfPolicyVersion: 2,
+  tcfPolicyVersion: 4,
   cmpId:1000,
   cmpVersion: 1000,
 
@@ -872,7 +831,7 @@ If the argument is `0` (Zero), `null` or `undefined`, the CMP shall return the i
 
 If the argument is invalid (i.e. not a positive integer greater than `1` or higher than the highest supported version for this CMP) the CMP shall invoke the callback with an argument of `false` for the success parameter and a `null` argument for any expected TC data parameter.
 
-If the argument is `1`, the CMP shall invoke the callback with an argument of `false` for the success parameter and a `null` argument for any expected TC data parameter, as this TCF version is no longer supported by this API. Vendors should instead use the version `1` API to get version `1` data (see [v1.1 documentation](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/CMP%20JS%20API%20v1.1%20Final.md#consent-management-provider-javascript-api-v11-transparency--consent-framework)).
+If the argument is `1`, the CMP shall invoke the callback with an argument of `false` for the success parameter and a `null` argument for any expected TC data parameter, as this TCF version is no longer supported by this API.
 
 If the argument is an integer higher than `1`, the CMP shall invoke the callback with defined data according to the specified version if it exists in that version.  For obvious reasons, if new properties of the version-specific outlined TC data objects are added in v3, a v2 TC data object shall not contain these new properties because they may either not exist or may have different meaning from version to version.
 
@@ -1092,6 +1051,8 @@ __tcfapi('ping', 2, (pingReturn, success) => {
 
 See the ‘How should the transparency & consent string be stored?’ section in the ‘Transparency & Consent String and Global Vendor List Format’ spec which describes where CMPs must store the transparency & consent string.
 
+## Major Changes from 2.0
+1. Deprecated command `getTCData`
 
 ## Major Changes from 1.1
 

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -2,7 +2,7 @@
 # Consent Management Platform API
 **IAB Europe Transparency & Consent Framework**
 
-**Final v.2.1 May 2023**
+**Final v.2.2 May 2023**
 
 - [Version History](#version-history)
 - [Introduction](#introduction)
@@ -56,7 +56,7 @@
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
-| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: Deprecated API command "getTCData".
+| May 2023 | 2.2 | Update to further strengthen the TCF as a standard in the industry: Deprecated API command "getTCData".
 | September 2021 | 2.0 | Deprecation of Global Scope and OOB |
 | February 2020 | 2.0 | Removed CMP List; added included in the Consent String and Vendor List Specification |
 | February 2020 | 2.0 | Updated stub example to reference open-source library, change addEventListener/removeEventListener interface, clarify addEventListener callback invocation time, and remove SafeFrame proxy communications |

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -351,10 +351,10 @@ TCData = {
   isServiceSpecific: Boolean,
 
   /**
-   * true - CMP is using publisher-customized stack descriptions
-   * false - CMP is NOT using publisher-customized stack descriptions
+   * true - CMP is using publisher-customized stack descriptions and/or modified or supplemented standard Illustrations
+   * false - CMP is NOT using publisher-customized stack descriptions and or modified or supplemented standard Illustrations
    */
-  useNonStandardStacks: Boolean,
+  useNonStandardTexts: Boolean,
 
   /**
    * Country code of the country that determines the legislation of
@@ -582,10 +582,10 @@ InAppTCData = {
   isServiceSpecific: 1,
 
   /**
-   * 1 - CMP is using publisher-customized stack descriptions
-   * 0 - CMP is NOT using publisher-customized stack descriptions
+   * 1 - CMP is using publisher-customized stack descriptions and/or modified or supplemented standard Illustrations
+   * 0 - CMP is NOT using publisher-customized stack descriptions and/or modified or supplemented standard Illustrations
    */
-  useNonStandardStacks: 1,
+  useNonStandardTexts: 1,
 
   /**
    * Country code of the country that determines the legislation of
@@ -718,7 +718,7 @@ The steps for integrating a CMP SDK into an app are the following:
 | `IABTCF_gdprApplies`  | `Number`: <p>`1` GDPR applies in current context</p><p>`0` - GDPR does _**not**_ apply in current context</p><p>**Unset** - undetermined (default before initialization)</p><p>see the section ["What does the gdprApplies value mean?"](#what-does-the-gdprapplies-value-mean) for more</p> |
 | `IABTCF_PublisherCC`  | `String`: [Two-letter ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) – Default: `AA` (unknown) |
 | `IABTCF_PurposeOneTreatment`  | `Number`: <p>`0` - no special treatment of purpose one</p><p>`1` - purpose one not disclosed</p><p>**Unset default** - `0`</p><p>Vendors can use this value to determine whether consent for purpose one is required.</p> |
-| `IABTCF_UseNonStandardStacks`  | `Number`: <p>`1` - CMP used a non-standard stack</p><p>`0` - CMP did not use a non-standard stack</p> |
+| `IABTCF_UseNonStandardTexts`  | `Number`: <p>`1` - CMP uses customized stack descriptions and/or modified or supplemented standard Illustrations</p><p>`0` - CMP did not use a non-standard stack desc. and/or modified or supplemented Illustrations</p> |
 | `IABTCF_TCString` | `String`: Full encoded TC string |
 | `IABTCF_VendorConsents` | `Binary String`: The `'0'` or `'1'` at position **n** – where **n**'s indexing begins at `0`  – indicates the consent status for Vendor ID **n+1**; `false` and `true` respectively. eg. `'1'` at index `0` is consent `true` for vendor ID `1` |
 | `IABTCF_VendorLegitimateInterests` | `Binary String`: The `'0'` or `'1'` at position **n** – where **n**'s indexing begins at `0`  – indicates the legitimate interest status for Vendor ID **n+1**; `false` and `true` respectively. eg. `'1'` at index `0` is legitimate interest established `true` for vendor ID `1` |

--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -187,18 +187,6 @@ const callback = (tcData, success) => {
 
     // do something with tcData.tcString
 
-    // remove the ourself to not get called more than once
-    __tcfapi('removeEventListener', 2, (success) => {
-
-      if(success) {
-
-        // oh good...
-
-      }
-
-    }, tcData.listenerId);
-
-
   } else {
 
     // do something else

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -361,7 +361,7 @@ The IAB Europe Transparency & Consent Framework [Policies](https://iabeurope.eu/
 
 #### Managing conflicting string versions
 
-With the release of TCF v2.2, the policy version has been incremented to version 4. Post 30 September 2023 a TC String with a policy version set to smaller than 4 will be deemed invalid.
+With the release of TCF v2.2, the policy version has been incremented to version 4. Post 30 September 2023 a TC String created with a policy version set to smaller than 4 will be deemed invalid. TC Strings with policy version 3 created until 30 September 2023 may still be returned by the CMP API post 30 September 2023"
 
 Post 30 September 2020, [v1.x strings were considered invalid](https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/). If a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -1641,10 +1641,9 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
    * "dataDeclaration": An array of positive integers that represent
    * the data categories declared by the vendor.
    *
-   * "dataRetention": an object that contains the data retention for each purpose
-   * and specialPurpose. A stdRetention is computed and added if there is an
-   * absolute total of equal retention periods found. A dataRetention of -1 means 
-   * that no retention was given due to the purpose not being used.
+   * "dataRetention": an object that contains the data retention for the purpose
+   * and specialPurpose declared by the vendor. A stdRetention is computed and 
+   * added if there is an absolute total of equal retention periods found.
    *
    * "urls": an array of url objects representing language, policy url and
    * legitimate interest url. At least one entry is REQUIRED. Up to 40 languages
@@ -1676,7 +1675,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   "1":{
      "id": 1,
 	   "name": "Vendor Name",
-	   "purposes": [1, 2, 9],
+	   "purposes": [1, 2, 3, 9],
 	   "specialPurposes": [1],
 	   "legIntPurposes": [2],
 	   "flexiblePurposes": [1, 2],
@@ -1684,7 +1683,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
 	   "specialFeatures": [1, 2],
      "dataRetention": {
           "stdRetention": 30
-          "purposes": { "3": -1, "4": -1, "5": -1, "6": -1, "7": -1, "8": -1, "9": 180 , "10:" -1},
+          "purposes": { "9": 180 },
           "specialPurposes": {}
       },
      "dataDeclaration" : [ 1, 2, 4, 6 ],

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -515,16 +515,12 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
         gathering<br /><code>0</code> IAB standard texts were used
       </td>
       <td>
-        Setting this to 1 means that a publisher-run CMP – that is still IAB
-        Europe registered – is using customized text for stack descriptions or customized
-        illustrations and not the standard stack descriptions or illustrations defined
-        in the
+        Setting this to 1 means that a publisher is using customized texts (Stack descriptions or Illustrations) and not the standard texts defined in the
         <a
           href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/"
           >Policies</a
         >
-        (Appendix A section E). A CMP that services multiple publishers sets
-        this value to <code>0</code>.
+       (Appendix A) in accordance with the permissions described in Chapter III(21): (6)&(7). A CMP that services multiple publishers sets this value to <code>0</code>.
       </td>
     </tr>
     <tr>

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -508,15 +508,15 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       </td>
     </tr>
     <tr>
-      <td>UseNonStandardStacks</td>
+      <td>UseNonStandardTexts</td>
       <td>1 bit</td>
       <td>
-        <code>1</code> CMP used non-IAB standard stacks or illustrations during consent
-        gathering<br /><code>0</code> IAB standard stacks and illustrations were used
+        <code>1</code> CMP used non-IAB standard texts during consent
+        gathering<br /><code>0</code> IAB standard texts were used
       </td>
       <td>
         Setting this to 1 means that a publisher-run CMP – that is still IAB
-        Europe registered – is using customized Stack descriptions or customized
+        Europe registered – is using customized text for stack descriptions or customized
         illustrations and not the standard stack descriptions or illustrations defined
         in the
         <a

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -64,9 +64,9 @@
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
-| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
-| June 2022 | 2.0 | Update of the <b>Global Vendor List JSON Object</b> example regarding the filename in `deviceStorageDisclosureUrl` |
-| Feb 2022 | 2.0 | Move the current vendor fields relating to the Planet 49 ruling from the existing Device Storage Access & Disclosure tech spec to this core spec |
+| May 2023 | 2.2 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
+| June 2022 | 2.1 | Update of the <b>Global Vendor List JSON Object</b> example regarding the filename in `deviceStorageDisclosureUrl` |
+| Feb 2022 | 2.1 | Move the current vendor fields relating to the Planet 49 ruling from the existing Device Storage Access & Disclosure tech spec to this core spec |
 | Dec 2021 | 2.0 | Update of Created and LastUpdated to have the same value corresponding to the day-level timestamp of when the TC String was last updated |
 | Sept 2021 | 2.0 | Deprecation of Global Scope, OOB and 'euconsent-v2' cookie associated with the consensu.org domain  |
 | August 2021 | 2.0 | Added optional use of DisclosedVendor segment in the context of storing service-level TC Strings  |
@@ -1581,13 +1581,13 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   //
   },
 
-  "personalDataCategories": {
+  "dataCategories": {
 	"1": {
 	   "id": 1,
 	   "name" : "IP addresses",
 	   "description" : "..."
 	}
-  // ... more personalDataCategories.
+  // ... more dataCategories.
   //
   },
 
@@ -1638,8 +1638,8 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
    * empty. List of Special Features the Vendor may utilize when performing
    * some declared Purposes processing.
    *
-   * "personalDataDeclaration": An array of positive integers that represent
-   * the persona data categories declared by the vendor.
+   * "dataDeclaration": An array of positive integers that represent
+   * the data categories declared by the vendor.
    *
    * "dataRetention": an object that contains the data retention for each purpose
    * and specialPurpose. A stdRetention is computed and added if there is an
@@ -1687,7 +1687,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
           "purposes": { "3": -1, "4": -1, "5": -1, "6": -1, "7": -1, "8": -1, "9": 180 , "10:" -1},
           "specialPurposes": {}
       },
-     "personalDataDeclaration" : [ 1, 2, 4, 6 ],
+     "dataDeclaration" : [ 1, 2, 4, 6 ],
      "urls": [
         {
           "langId": "en",

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -520,7 +520,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
           href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/"
           >Policies</a
         >
-       (Appendix A) in accordance with the permissions described in Chapter III(21): (6)&(7). A CMP that services multiple publishers sets this value to <code>0</code>.
+       (Appendix A) in accordance with the permissions described in Chapter IV(21): (6)&(7). A CMP that services multiple publishers sets this value to <code>0</code>.
       </td>
     </tr>
     <tr>

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -2,7 +2,7 @@
  # Transparency and Consent String with Global Vendor & CMP List Formats
  **IAB Europe Transparency & Consent Framework**
 
- **Final v.2.1 May 2023**
+ **Final v.2.2 May 2023**
 
  Table of Contents
 
@@ -343,7 +343,7 @@ The Created and LastUpdated fields previously corresponded to decisecond timesta
 
 ### Why was support for legitimate interest for purposes 3 to 6 deprecated?
 
-In order to strengthen the TCF as a standard within the industry it was decided with version 2.1 to prohibit reliance on Legitimate Interest for purpose 3 (create a personalised ads profile), purpose 4 (select personalised ads), purpose 5 (create a personalised content profile) and purpose 6 (select personalised content).
+In order to strengthen the TCF as a standard within the industry it was decided with version 2.2 to prohibit reliance on Legitimate Interest for purpose 3 (create a personalised ads profile), purpose 4 (select personalised ads), purpose 5 (create a personalised content profile) and purpose 6 (select personalised content).
 
 ## Creating a TC String
 
@@ -361,7 +361,7 @@ The IAB Europe Transparency & Consent Framework [Policies](https://iabeurope.eu/
 
 #### Managing conflicting string versions
 
-With the release of TCF v2.1, the policy version has been incremented to version 4. Post 30 September 2023 a TC String with a policy version set to smaller than 4 will be deemed invalid.
+With the release of TCF v2.2, the policy version has been incremented to version 4. Post 30 September 2023 a TC String with a policy version set to smaller than 4 will be deemed invalid.
 
 Post 30 September 2020, [v1.x strings were considered invalid](https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/). If a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 
@@ -589,7 +589,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
           <code>0</code>. From left to right, Purpose 1 maps to the 0th bit,
           and purpose 24 maps to the bit at index 23. Special Purposes are a
           different ID space and not included in this field.<br>
-          Note: With TCF v2.1 support for legitimate interest for purpose 3
+          Note: With TCF v2.2 support for legitimate interest for purpose 3
           to 6 has been deprecated. Bits 2 to 5 are required to be set
           to <code>0</code>.
         </p>

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -496,9 +496,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       <td>
         From the corresponding field in the
         <a href="#the-global-vendor-list">GVL</a> that was used for
-        obtaining consent. A new policy version invalidates existing strings
-        and requires CMPs to re-establish transparency and consent from
-        users.
+        obtaining consent.
       </td>
     </tr>
     <tr>
@@ -513,13 +511,14 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       <td>UseNonStandardStacks</td>
       <td>1 bit</td>
       <td>
-        <code>1</code> CMP used non-IAB standard stacks during consent
-        gathering<br /><code>0</code> IAB standard stacks were used
+        <code>1</code> CMP used non-IAB standard stacks or illustrations during consent
+        gathering<br /><code>0</code> IAB standard stacks and illustrations were used
       </td>
       <td>
         Setting this to 1 means that a publisher-run CMP – that is still IAB
-        Europe registered – is using customized Stack descriptions and not
-        the standard stack descriptions defined in the
+        Europe registered – is using customized Stack descriptions or customized
+        illustrations and not the standard stack descriptions or illustrations defined
+        in the
         <a
           href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/"
           >Policies</a
@@ -1367,7 +1366,7 @@ The GVL is in JSON format and the current version at any given time can be retri
 
 Previous versions of the Global Vendor List are available here:
 
-[https://vendor-list.consensu.org/v3/archives/vendor-list-v{vendor-list-version}.json](https://vendor-list.consensu.org/v3/archives/vendorlist-v{vendor-list-version}.json)
+[https://vendor-list.consensu.org/v3/archives/vendor-list-v{vendor-list-version}.json](https://vendor-list.consensu.org/v3/archives/vendor-list-v{vendor-list-version}.json)
 
 Where ‘vendor-list-version’ corresponds to the ‘vendorListVersion’ property in the GVL, for example, the following URL would retrieve the GVL update published with version 138
 
@@ -1495,7 +1494,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
  	* "id": number, REQUIRED
  	* "name": string, REQUIRED
  	* "description": string, REQUIRED
- 	* "descriptionLegal": string, REQUIRED
+ 	* "illustrations": string array, REQUIRED
  	* "consentable": boolean, OPTIONAL, default=true  false means CMPs should never afford users the means to provide an opt-in consent choice
  	* "rightToObject": boolean, OPTIONAL, default=true  false means CMPs should never afford users the means to exercise a right to object
 	*/
@@ -1503,14 +1502,14 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   	   "id": 1,
   	   "name": "Storage and access of information",
   	   "description": "...",
-  	   "descriptionLegal": "..."
+  	   "illustrations": [ ]
 	},
 	// ... more purposes from id=2 to id=9 (up to no higher than id=24)
 	"10": {
   	   "id": 10,
   	   "name": "Develop and improve product",
   	   "description": "...",
-  	   "descriptionLegal": "...",
+  	   "illustrations": [ ],
   	   "consentable": false,
   	   "rightToObject": false
 	}
@@ -1520,7 +1519,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   	   "id": 1,
   	   "name": "Security, Fraud Prevention, Debugging",
   	   "description": "...",
-  	   "descriptionLegal": "...",
+  	   "illustrations": [ ],
   	   "consentable": false,
   	   "rightToObject": false
 	},
@@ -1528,7 +1527,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   	   "id": 2,
   	   "name": "Technical ad and content delivery",
   	   "description": "...",
-  	   "descriptionLegal": "...",
+  	   "illustrations": [ ],
   	   "consentable": false,
   	   "rightToObject": false
 	}
@@ -1538,7 +1537,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   	   "id": 1,
   	   "name": "Matching Data to Offline Sources",
   	   "description": "Combining data from offline sources that were initially collected in other contexts",
-  	   "descriptionLegal": "..."
+  	   "illustrations": [ ]
 	}
 
   // ... more features from id=2 up to no higher than id=64.
@@ -1555,13 +1554,13 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   	   "id": 1,
   	   "name": "Precise Geolocation",
   	   "description": "...",
-  	   "descriptionLegal": "..."
+  	   "illustrations": [ ]
 	},
 	"2": {
   	   "id": 2,
   	   "name": "Active Fingerprinting",
   	   "description": "...",
-  	   "descriptionLegal": "..."
+  	   "illustrations": [ ]
 	}
 
   // ... more special features from id=3 up to no higher than id=8.

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -516,12 +516,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       </td>
       <td>
         Setting this to 1 signals to Vendors that a private CMP has modified standard Stack descriptions and/or their translations and/or that a CMP has modified or supplemented standard Illustrations and/or their translations 
-        as allowed by the 
-        <a
-          href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/"
-          >Policy</a
-        >
-       (Appendix A) in accordance with the permissions described in Chapter IV(21): (6)&(7).
+        as allowed by the policy.
       </td>
     </tr>
     <tr>

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -1485,7 +1485,7 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
 ```javascript
 {
   "gvlSpecificationVersion": 3,
-  "vendorListVersion": 201, // incremented with each published file change
+  "vendorListVersion": 1, // incremented with each published file change
   "tcfPolicyVersion": 4, // The TCF MO will increment this value whenever a GVL change (such as adding a new Purpose or Feature or a change in Purpose wording) legally invalidates existing TC Strings and requires CMPs to re-establish transparency and consent from users. TCF Policy changes should be relatively infrequent and only occur when necessary to support changes in global mandate. If the policy version number in the latest GVL is different from the value in your TC String, then you need to re-establish transparency and consent for that user. A version 1 format TC String is considered to have a version value of 1.
   "lastUpdated": "2023-05-26T16:00:00Z",
   "purposes": {

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -64,7 +64,7 @@
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
-| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removal of legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
+| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
 | June 2022 | 2.0 | Update of the <b>Global Vendor List JSON Object</b> example regarding the filename in `deviceStorageDisclosureUrl` |
 | Feb 2022 | 2.0 | Move the current vendor fields relating to the Planet 49 ruling from the existing Device Storage Access & Disclosure tech spec to this core spec |
 | Dec 2021 | 2.0 | Update of Created and LastUpdated to have the same value corresponding to the day-level timestamp of when the TC String was last updated |

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -515,12 +515,13 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
         gathering<br /><code>0</code> IAB standard texts were used
       </td>
       <td>
-        Setting this to 1 means that a publisher is using customized texts (Stack descriptions or Illustrations) and not the standard texts defined in the
+        Setting this to 1 signals to Vendors that a private CMP has modified standard Stack descriptions and/or their translations and/or that a CMP has modified or supplemented standard Illustrations and/or their translations 
+        as allowed by the 
         <a
           href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/"
-          >Policies</a
+          >Policy</a
         >
-       (Appendix A) in accordance with the permissions described in Chapter IV(21): (6)&(7). A CMP that services multiple publishers sets this value to <code>0</code>.
+       (Appendix A) in accordance with the permissions described in Chapter IV(21): (6)&(7).
       </td>
     </tr>
     <tr>

--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -2,7 +2,7 @@
  # Transparency and Consent String with Global Vendor & CMP List Formats
  **IAB Europe Transparency & Consent Framework**
 
- **Final v.2.0 | August 2019, Updated June 2022**
+ **Final v.2.1 May 2023**
 
  Table of Contents
 
@@ -64,6 +64,7 @@
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
+| May 2023 | 2.1 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removal of legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
 | June 2022 | 2.0 | Update of the <b>Global Vendor List JSON Object</b> example regarding the filename in `deviceStorageDisclosureUrl` |
 | Feb 2022 | 2.0 | Move the current vendor fields relating to the Planet 49 ruling from the existing Device Storage Access & Disclosure tech spec to this core spec |
 | Dec 2021 | 2.0 | Update of Created and LastUpdated to have the same value corresponding to the day-level timestamp of when the TC String was last updated |
@@ -90,7 +91,7 @@ IAB Europe established the TCF to support compliance with the GDPR in the contex
 
 Prescribed use of the TCF may support compliance with the GDPR, but the real benefit to the digital advertising ecosystem is a safer Internet for consumers, and more reliable data for brands and publishers. As adoption of the TCF increases, compliance becomes more scalable and data becomes more meaningful.
 
-To participate in the use of the TCF, vendors must make a public attestation of compliance with the [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) for using it. To have transparency and consent established and signaled status for your online services stored in a global database, apply to be added to the [GVL](#the-global-vendor-list). To play a role in creating a TC String for signaling status on transparency and user consent, sign up with IAB Europe to become a CMP. CMPs must follow technical standards provided in this document for creating TC Strings in compliance with TCF [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/). They must also follow technical standards guidance for using the CMP API specified in this document to receive and process information provided in a TC String.
+To participate in the use of the TCF, vendors must make a public attestation of compliance with the [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) for using it. Register as a vendor and be listed in the [GVL](#the-global-vendor-list) to signal your status having transparency and consent established for your online services. To play a role in creating a TC String for signaling status on transparency and user consent, sign up with IAB Europe to become a CMP. CMPs must follow technical standards provided in this document for creating TC Strings in compliance with TCF [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/). They must also follow technical standards guidance for using the CMP API specified in this document to receive and process information provided in a TC String.
 
 ### Audience
 
@@ -298,9 +299,7 @@ The service making the call must replace the macros with appropriate values desc
       <td><code>${GDPR}</code></td>
       <td><code>0</code> / <code>1</code></td>
       <td>
-        <code>0</code> GDPR does not apply; <code>1</code> GDPR applies. If
-        not present, callee should do geoIP lookup, and GDPR applies for EU
-        IP addresses
+        <code>0</code> GDPR does not apply; <code>1</code> GDPR applies.
       </td>
     </tr>
     <tr>
@@ -342,6 +341,10 @@ To accommodate cases where Purpose 1 is governed differently for consent dependi
 
 The Created and LastUpdated fields previously corresponded to decisecond timestamps. Considering practical guidance from DPAs relating to the the various means that can be employed by data controllers to provide evidence of the consent obtained and its validity and the limited relevance of the Created field for publishers and their CMPs to fulfill the requirements of remaining users of their choices, as appropriate and at least every 13 months, the Created and LastUpdated fields have been updated to have the **same value** corresponding to the **day-level timestamp** of when the TC String was last updated.
 
+### Why was support for legitimate interest for purposes 3 to 6 deprecated?
+
+In order to strengthen the TCF as a standard within the industry it was decided with version 2.1 to prohibit reliance on Legitimate Interest for purpose 3 (create a personalised ads profile), purpose 4 (select personalised ads), purpose 5 (create a personalised content profile) and purpose 6 (select personalised content).
+
 ## Creating a TC String
 
 The following details provide information on creating, storing, and managing a TC String.
@@ -357,6 +360,8 @@ The IAB Europe Transparency & Consent Framework [Policies](https://iabeurope.eu/
 [https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/)
 
 #### Managing conflicting string versions
+
+With the release of TCF v2.1, the policy version has been incremented to version 4. Post 30 September 2023 a TC String with a policy version set to smaller than 4 will be deemed invalid.
 
 Post 30 September 2020, [v1.x strings were considered invalid](https://iabeurope.eu/all-news/the-iab-europe-transparency-consent-framework-tcf-steering-group-votes-to-extend-technical-support-for-tcf-v1-1/). If a CMP encounters a situation where both a v1.x string and a v2.0 string are erroneously present simultaneously, the CMP should remove the v1.x string to ensure that there is only one source of truth for consumers of the string.
 
@@ -582,8 +587,11 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
           By default or if the user has exercised their “Right to Object” to
           a Purpose, the corresponding bit for that Purpose is set to
           <code>0</code>. From left to right, Purpose 1 maps to the 0th bit,
-          purpose 24 maps to the bit at index 23. Special Purposes are a
-          different ID space and not included in this field.
+          and purpose 24 maps to the bit at index 23. Special Purposes are a
+          different ID space and not included in this field.<br>
+          Note: With TCF v2.1 support for legitimate interest for purpose 3
+          to 6 has been deprecated. Bits 2 to 5 are required to be set
+          to <code>0</code>.
         </p>
       </td>
     </tr>
@@ -1311,7 +1319,7 @@ The _**[Publisher TC](#publisher-purposes-transparency-and-consent)**_ segment i
 
 ## The Global Vendor List
 
-The Global Vendor List (GVL) is a technical document that CMPs download from a domain managed and published by IAB Europe. It lists all registered and approved Vendors, as well as standard Purposes, Special Purposes, Features, Special Features and Stacks. The information stored in the GVL is used for determining what legal disclosures must be made to the user.
+The Global Vendor List (GVL) is a technical document that CMPs download from a domain managed and published by IAB Europe. It lists all registered and approved Vendors, as well as standard Purposes, Special Purposes, Features, Special Features, Stacks, and categories of data collected in conjunction with the purposes. The information stored in the GVL is used for determining what legal disclosures must be made to the user.
 
 ### I’m a vendor, how do I get added to the Global Vendor List?
 
@@ -1326,8 +1334,9 @@ The registration process is described here: [https://iabeurope.eu/tcf](https://i
 *   A list of standard Purposes
 *   A list of Special Purposes
 *   A list of standard Features
-*   A list of Special Features.
+*   A list of Special Features
 *   A list of Stacks
+*   A list of Categories of data collected
 *   A list of Vendors and their:
     *   Numeric ID which is incrementally assigned and never re-used – deleted Vendors are just marked as deleted.
     *   Name.
@@ -1337,7 +1346,9 @@ The registration process is described here: [https://iabeurope.eu/tcf](https://i
     *   List of Special Purposes to transparently disclose as their legitimate interest that a user has no right to object.
     *   List of Features they use across Purposes.
     *   List of Special Features they use across Purposes.
-    *   GDPR/privacy policy page URL.
+    *   List of Categories of data collected across Purposes.
+    *   Data retention duration for each purpose as applicable.
+    *   GDPR/privacy policy page and Legitimate Interest claim URL.
     *   HTTP “overflow” options which includes a <code>GET</code> request maximum size in kilobytes to help diagnose problems with TC String passing as well as limit oversized strings.
     *   Whether they use cookie storage (session or otherwise).
     *   The longest potential device storage duration, as set when using the cookie method of storage.
@@ -1352,15 +1363,15 @@ Additional information on Vendors can be downloaded from a domain managed and pu
 
 The GVL is in JSON format and the current version at any given time can be retrieved using the following URL structure:
 
-[https://vendor-list.consensu.org/v2/vendor-list.json](https://vendor-list.consensu.org/v2/vendor-list.json)
+[https://vendor-list.consensu.org/v3/vendor-list.json](https://vendor-list.consensu.org/v3/vendor-list.json)
 
 Previous versions of the Global Vendor List are available here:
 
-[https://vendor-list.consensu.org/v2/archives/vendor-list-v{vendor-list-version}.json](https://vendor-list.consensu.org/v2/archives/vendorlist-v{vendor-list-version}.json)
+[https://vendor-list.consensu.org/v3/archives/vendor-list-v{vendor-list-version}.json](https://vendor-list.consensu.org/v3/archives/vendorlist-v{vendor-list-version}.json)
 
 Where ‘vendor-list-version’ corresponds to the ‘vendorListVersion’ property in the GVL, for example, the following URL would retrieve the GVL update published with version 138
 
-https://vendor-list.consensu.org/v2/archives/vendor-list-v138.json
+https://vendor-list.consensu.org/v3/archives/vendor-list-v138.json
 
 Previous versions of the GVL may only be used in cases when the current version cannot be downloaded (such as when operating in-app while offline), or for change control management.
 
@@ -1374,11 +1385,13 @@ For reference, the URL for version 1 of the TCF was:
 
 Version 1 of the Global Vendor List and all version 1 archives will continue to be maintained until support officially ends in 2020. At that time, these files will be deprecated and only version 2 and newer of the Global Vendor List will be available.
 
-### Translations for Purposes, Special Purposes, Features, and Special Features
+### Translations for Purposes, Special Purposes, Features, Special Features, and Categories of data
 
-Translations of the names and descriptions for Purposes, Special Purposes, Features, and Special Features to non-English languages are contained in a file where attributes containing English content (except vendor declaration information) are translated, and can be found here:
+Translations of the names and descriptions for Purposes, Special Purposes, Features, Special Features, and the categories of data used in conjunction with purposes to non-English languages are contained in a 
+file where attributes containing English content (except vendor declaration information) are translated,
+and can be found here:
 
-https://vendor-list.consensu.org/v2/purposes-{language}.json
+https://vendor-list.consensu.org/v3/purposes-{language}.json
 
 Where ‘language’ is a two letter lowercase [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code. Supported languages are listed at the following URL:
 
@@ -1471,10 +1484,10 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
 
 ```javascript
 {
-  "gvlSpecificationVersion": 2,
-  "vendorListVersion": 133, // incremented with each published file change
-  "tcfPolicyVersion": 2, // The TCF MO will increment this value whenever a GVL change (such as adding a new Purpose or Feature or a change in Purpose wording) legally invalidates existing TC Strings and requires CMPs to re-establish transparency and consent from users. TCF Policy changes should be relatively infrequent and only occur when necessary to support changes in global mandate. If the policy version number in the latest GVL is different from the value in your TC String, then you need to re-establish transparency and consent for that user. A version 1 format TC String is considered to have a version value of 1.
-  "lastUpdated": "2022-05-26T16:00:00Z",
+  "gvlSpecificationVersion": 3,
+  "vendorListVersion": 201, // incremented with each published file change
+  "tcfPolicyVersion": 4, // The TCF MO will increment this value whenever a GVL change (such as adding a new Purpose or Feature or a change in Purpose wording) legally invalidates existing TC Strings and requires CMPs to re-establish transparency and consent from users. TCF Policy changes should be relatively infrequent and only occur when necessary to support changes in global mandate. If the policy version number in the latest GVL is different from the value in your TC String, then you need to re-establish transparency and consent for that user. A version 1 format TC String is considered to have a version value of 1.
+  "lastUpdated": "2023-05-26T16:00:00Z",
   "purposes": {
 	/**
  	* Information published for each Purpose
@@ -1568,6 +1581,16 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
   //
   },
 
+  "personalDataCategories": {
+	"1": {
+	   "id": 1,
+	   "name" : "IP addresses",
+	   "description" : "..."
+	}
+  // ... more personalDataCategories.
+  //
+  },
+
   "vendors": {
   /**
    * Information published for each vendor
@@ -1615,8 +1638,17 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
    * empty. List of Special Features the Vendor may utilize when performing
    * some declared Purposes processing.
    *
-   * "policyUrl": url string, REQUIRED URL to the Vendor's privacy policy
-   * document.
+   * "personalDataDeclaration": An array of positive integers that represent
+   * the persona data categories declared by the vendor.
+   *
+   * "dataRetention": an object that contains the data retention for each purpose
+   * and specialPurpose. A stdRetention is computed and added if there is an
+   * absolute total of equal retention periods found. A dataRetention of -1 means 
+   * that no retention was given due to the purpose not being used.
+   *
+   * "urls": an array of url objects representing language, policy url and
+   * legitimate interest url. At least one entry is REQUIRED. Up to 40 languages
+   * can be specified.
    *
    * "deletedDate": date string ("2019-05-28T00:00:00Z") OPTIONAL, If present,
    * vendor is considered deleted after this date/time and MUST NOT be
@@ -1642,15 +1674,33 @@ Here is an annotated example of the GVL’s JSON format and content. Some attrib
    *
    */
   "1":{
-       "id": 1,
+     "id": 1,
 	   "name": "Vendor Name",
-	   "purposes": [1],
+	   "purposes": [1, 2, 9],
 	   "specialPurposes": [1],
-	   "legIntPurposes": [2, 3],
+	   "legIntPurposes": [2],
 	   "flexiblePurposes": [1, 2],
 	   "features": [1, 2],
 	   "specialFeatures": [1, 2],
-	   "policyUrl": "https://vendorname.com/gdpr.html",
+     "dataRetention": {
+          "stdRetention": 30
+          "purposes": { "3": -1, "4": -1, "5": -1, "6": -1, "7": -1, "8": -1, "9": 180 , "10:" -1},
+          "specialPurposes": {}
+      },
+     "personalDataDeclaration" : [ 1, 2, 4, 6 ],
+     "urls": [
+        {
+          "langId": "en",
+          "privacy": "https://vendorname.com/gdpr.html",
+          "legIntClaim": "https://vendorname.com/gdpr.html#li"
+
+        },
+        {
+          "langId": "fr",
+          "privacy": "https://vendorname.com/fr/gdpr.html",
+          "legIntClaim": "https://vendorname.com/fr/gdpr.html#li"
+        }
+     ],
 	   "deletedDate": "2019-02-28T00:00:00Z",
 	   "overflow": {
       	      "httpGetLimit": 32
@@ -1719,7 +1769,7 @@ This true or false field indicates whether the vendor uses other, non-cookie met
  </table>
 
 ## Global CMP List Specification
-The Global CMP List (GCL) is a JSON format document that lists all CMPs registered with the Transparency and Consent Framework (TCF). There are separate files for v1.1 and v2 of the framework. These files are used by vendors to determine which CMPs are compliant and active within the framework, in order to ascertain whether a given CMP ID found in a consent string or TC String is valid.
+The Global CMP List (GCL) is a JSON format document that lists all CMPs registered with the Transparency and Consent Framework (TCF). There are separate files for each version of the framework. Currently, we only support TCF v2. These files are used by vendors to determine which CMPs are compliant and active within the framework, in order to ascertain whether a given CMP ID found in a consent string or TC String is valid.
 
 IMPORTANT NOTE: all CMPs that have registered with the TCF are listed in these files. CMPs that are no longer active for whatever reason, have the `deletedDate` property set. Consent strings or TC Strings for CMPs with a `deletedDate` set must be considered invalid after that date/time and must be discarded immediately and not passed downstream.
 

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -14,8 +14,7 @@
 This document provides technical implementation guidelines related to the [IAB Europe Transparency and Consent Framework (TCF) v2.2 technical specs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework). The IAB Tech Lab GDPR Technical Working Group has collaborated on the following implementation guidelines, and will continue to produce resources supporting industry adoption of the Framework. The intended audience of this document includes product and engineering teams who are building technology based on this framework, and who are looking for guidance on implementation strategies such as questions to ask your platform partners or avoiding common pitfalls.
 
 Policy FAQ, webinars, and other resources are available at 
-[https://iabeurope.eu/tcf-2-0/](https://iabeurope.eu/tcf-2-0/)
-
+[https://www.iabeurope.eu/tcf](https://www.iabeurope.eu/tcf))
 
 ### [Introduction to the TCF](#Intro)<br>
 ### [Common Questions](#commonquestions)<br>

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -2,61 +2,56 @@
 
 <table>
 <tr>
+	<td><b>Last update</b></td>
+    <td>May 2023</td>
+</tr>
+<tr>
 	<td><b>Created</b></td>
     <td>August 2019</td>
 </tr>
-<tr>
-	<td><b>Last update</b></td>
-    <td>May 2022</td>
-</tr>
 </table>
 
-This document provides technical implementation guidelines related to the [IAB Europe Transparency and Consent Framework (TCF) v2 technical specs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework). The IAB Tech Lab GDPR Technical Working Group has collaborated on the following implementation guidelines, and will continue to produce resources supporting industry adoption of the Framework. The intended audience of this document includes product and engineering teams who are building technology based on this framework, and who are looking for guidance on implementation strategies such as questions to ask your platform partners or avoiding common pitfalls.
+This document provides technical implementation guidelines related to the [IAB Europe Transparency and Consent Framework (TCF) v2.1 technical specs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework). The IAB Tech Lab GDPR Technical Working Group has collaborated on the following implementation guidelines, and will continue to produce resources supporting industry adoption of the Framework. The intended audience of this document includes product and engineering teams who are building technology based on this framework, and who are looking for guidance on implementation strategies such as questions to ask your platform partners or avoiding common pitfalls.
 
 Policy FAQ, webinars, and other resources are available at 
-[https://www.iabeurope.eu/tcf](https://www.iabeurope.eu/tcf)
+[https://iabeurope.eu/tcf-2-0/](https://iabeurope.eu/tcf-2-0/)
 
 
 ### [Introduction to the TCF](#Intro)<br>
 ### [Common Questions](#commonquestions)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Do I need to read the Policy?](#needpolicy)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2?](#changes)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.1?](#changesV2_1)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2?](#changesV2)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Within the Transparency and Consent String (TC String)](#changetcstring)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Within the Global Vendor List (GVL) Format](#changegvl)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Within the Consent Management Platform API](#changecmp)<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[What is legitimate interest, and what’s new for vendor registration?](#whatisli)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[Is v2 backwards compatible?](#compatibility)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How do I evaluate the details provided in the TC String?](#evaluatetcstring)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How should I handle multiple signals with different information?](#mergesignals)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[What happened to Global Scope and Out of Band?](#gsoob)**<br>
 ### [Publisher guidelines](#pub)
 &nbsp;&nbsp;&nbsp;&nbsp;**[What is a Consent Management Platform (CMP) and why do I, as a Publisher, need one?](#whatiscmp)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[What publisher controls are available? What happened to Pubvendors?](#pubvendors)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What publisher controls are available?](#pubcontrols)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[The Global Vendor List](#gvl)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Withdrawal of consent](#withdraw)**<br>
-### [Vendor guidelines (DSPs, Agencies, DMPs)](#vendor)
+### [Vendor guidelines](#vendor)
 &nbsp;&nbsp;&nbsp;&nbsp;**[How do I find the TC String?](#findtcstring)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How do I send the TC string?](#sendtcstring)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How to determine legal bases from the TC String?](#detlegalbasis)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How to determine if data may be transmitted?](#handletcstring)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[Agency guidelines](#agencyguide)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[DSP guidelines](#dspguide)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[DMP guidelines](#dmpguide)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[How does the TC String apply to non-OpenRTB situations?](#nonrtb)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What if I don’t receive the TC string?](#nostring)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What else is there to consider when integrating with the TCF?](#whatelse)**<br>
 ### [Consent Management Platform (CMP) guidelines](#cmp)
-&nbsp;&nbsp;&nbsp;&nbsp;**[1. Collecting consent from users](#collectconsent)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[2. Sharing consent with vendors](#shareconsent)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[3. Storing Consent](#storeconsent)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[4. Withdrawal of consent and other non-TCF policy](#withdrawconsent)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[5. Encoding publisher restrictions](#pubrestrenc)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;**[6. CMP interface requirements](#cmpreq)**<br>
-### [How do vendors outside the RTB bidstream query a CMP?](#outsidertb)
+&nbsp;&nbsp;&nbsp;&nbsp;**[Collecting consent from users](#collectconsent)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[Sharing consent with vendors](#shareconsent)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[Storing Consent](#storeconsent)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[Other GDPR rights](#otherrights)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[Encoding publisher restrictions](#pubrestrenc)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[CMP interface requirements](#cmpreq)**<br>
 ### [Other Frequently Asked Questions](#otherfaq)
 &nbsp;&nbsp;&nbsp;&nbsp;**[Are cookies required for working with the CMP API?](#cookiesrequired)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Can I also use the API for CCPA or other laws?](#ccpa)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Related resources](#resources)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Will these FAQ be updated?](#faqupdates)**<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[How can I learn more?](#learnmore)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[Will these FAQ be updated?](#faqupdates)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[How can I learn more?](#learnmore)**<br>
 
 
 # Introduction to the TCF <a name="intro"></a>
@@ -64,44 +59,43 @@ The Transparency and Consent Framework (TCF) was created to help all parties who
 
 It allows publishers and website operators to communicate to vendors, in a standardized way, what preferences users have expressed when it comes to their personal data. A vendor is a company that participates in the delivery of digital advertising within a publisher’s website, app, or other digital content, that either accesses an end user’s device or browser or processes personal data about end users visiting the publishers content.
 
-The TCF was first introduced in April 2018. This document refers to version 2 of the TCF, announced in August 2019, which introduces significant changes and is not backward-compatible with the earlier version.
+The TCF was first introduced in April 2018. This document refers to version 2.1 of the TCF, announced in May 2023, which introduces significant changes and is not backward-compatible with the earlier versions.
 
-The communication between publishers and vendors must pass through a Consent Management Platform (CMP). A CMP can be operated by anyone, as long as the entity that operates it has completed registration on the CMP list  and is approved by IAB Europe . A list of all approved CMPs is available [here](https://iabeurope.eu/cmp-list/).
+The communication between publishers and vendors must pass through a Consent Management Platform (CMP). A CMP can be operated by anyone, as long as the entity that operates it has completed registration and is approved by IAB Europe. A list of all approved CMPs is available [here](https://iabeurope.eu/cmp-list/).
 
-CMPs centralise and manage transparency for and consent and objections of the end users, acting as an intermediary between the Publisher, end user and vendors, using information distributed via the Global Vendor List (GVL), which contains the updated list of vendors adhering to the framework. Please refer to the Policy for complete definition of a CMP. Only CMPs can write and read the Transparency and Consent string, where consent is stored. Their role is to make this information available to vendors within the technical specifications that the framework states.
+CMPs centralise and manage transparency for and consent and objections of the end users, acting as an intermediary between the Publisher, end user and vendors, using information distributed via the Global Vendor List (GVL), which contains the updated list of vendors adhering to the framework. Please refer to the Policy for complete definition of a CMP. Only CMPs can write the Transparency and Consent string, where consent is stored. Their role is to make this information available to vendors within the technical specifications that the framework states.
 
-When configuring their CMP, publishers can make a number of decisions:
-- Consent can be shared with all other publishers adhering to the framework or kept local to the specific publisher;
-- A number of restrictions can be applied, including allowing only a selected list of vendors to process data through their properties.
-A current list of vendors adhering to the framework can be found [here](https://vendor-list.consensu.org/v2/vendor-list.json).
+When configuring their CMP, publishers can make a number of decisions, including allowing only a selected list of vendors to process data through their properties. A current list of vendors adhering to the framework can be found [here](https://vendor-list.consensu.org/v2/vendor-list.json).
 
 Any party considering adoption of the TCF must read and follow the TCF Policies, outlined in the [IAB Europe Transparency & Consent Framework Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/). Correct implementation of the framework is impossible without following the requirements in the TCF Policy.
 
 ## Who should read this document?
-Publishers, Vendors (DMP, AdServer, Advertisers, …) and registered CMPs who want to work within the TCF can use this document as guidance to implement the technology to support their efforts. This document addresses common (technical) questions and makes it easier for companies to understand the coherences of the TCF policy and technical specifications.
+Publishers, Vendors (DMP, AdServer, Advertisers, audience measurement solutions, …) and registered CMPs who want to work within the TCF can use this document as guidance to implement the technology to support their efforts. This document addresses common (technical) questions and makes it easier for companies to understand the coherences of the TCF policy and technical specifications.
 
 ## How can I submit my questions?
-You can learn more about IAB Tech Lab support of the TCF and involvement with IAB Europe at the following URL: 
+You can learn more about IAB Tech Lab's support of the TCF and involvement with IAB Europe at the following URL: https://iabtechlab.com/standards/gdpr-transparency-and-consent-framework/
 
-https://iabtechlab.com/standards/gdpr-transparency-and-consent-framework/
+General information about the TCF can be found at: https://iabeurope.eu/transparency-consent-framework/.
 
-You can also submit general feedback on IAB Tech Lab draft specifications to framework@iabeurope.eu and any technical feedback to transparencyframework@iabtechlab.com. 
+You can also submit your inquiries and questions regarding the TCF to framework@iabeurope.eu and transparencyframework@iabtechlab.com.
 
 # Common Questions <a name="commonquestions"></a>
 ## Do I need to read the Policy? <a name="needpolicy"></a>
-Yes, the technical specifications for the TC String and CMP API were developed to support policies outlined in the Transparency and Consent Framework (TCF) Policies for version 2. Implementing the technology requires adherence to these policies.
+Yes, the technical specifications for the TC String and CMP API were developed to support policies outlined in the Transparency and Consent Framework (TCF) Policies. Implementing the technology requires adherence to these policies.
 
 If you have not yet read tech specs or policy, you can access these documents here: 
 - [IAB Europe Transparency and Consent Framework Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/)
-- [Transparency and Consent String, Version 2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
-- [Consent Management Platform API, Version 2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
+- [Transparency and Consent String, Version 2.1](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
+- [Consent Management Platform API, Version 2.1](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
 
 All definitions in the implementation guidelines should reflect definitions provided in the Policy. 
 
-## What changed in v2?<a name="changes"></a>
-Version 2 of the policy and technical specification marks significant updates to better support GDPR legislation and enhance the user experience, while remaining flexible to account for unique scenarios within the framework. 
+## What changed in v2.1?<a name="changesV2_1"></a>
+The TCF v2.1 update further strengthens the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls, deprecation of the __tcfapi command "getTCData" and introducing a more robust vendor compliance program.
 
-Changes across the Framework are listed below and grouped according to supporting documentation for: the TC String, the Global Vendor List,  and the CMP API. 
+## What changed in v2?<a name="changesV2"></a>
+Version 2 of the policy and technical specification marked significant updates to better support GDPR legislation and enhance the user experience, while remaining flexible to account for unique scenarios within the framework.
+Changes across the Framework are listed below and grouped according to supporting documentation for: the TC String, the Global Vendor List, and the CMP API.
 
 ### Within the Transparency and Consent String (TC String)<a name="changetcstring"></a>
 - Special jurisdiction handling using publisher country code
@@ -126,24 +120,15 @@ Changes across the Framework are listed below and grouped according to supportin
 - Addition of in-app “command” for in-app specific values
 - Updates to support special jurisdiction, and publisher restrictions
 
-## What is legitimate interest, and what’s new for vendor registration?<a name="whatisli"></a>
-Under the GDPR, a legal basis is required for processing a user’s data. While consent is the most common legal basis for processing a user’s data, legitimate interest is another legal basis that a vendor may use. For more information legitimate interest and when it can be used as a legal basis, please visit gdpr-info.eu where the regulation is posted. Chapter 2, article 6, describes legal bases under the GDPR. 
-
-## Is v2 backwards compatible? <a name="compatibility"></a>
-No. The changes in v2 are substantial enough that a completely new implementation is required. With the list of features, purposes, stacks, new structure for the TC String, and a number of other changes, none of the updates map to anything in previous versions. After an initial transition phase in v2 adoption, older versions will be deprecated.
-
 ## How do I evaluate the details provided in the TC String?<a name="evaluatetcstring"></a>
-The TC String returned by the CMP API can include (2) segments of information : the core string and the publisher TC segment. The technical specs describing the TC String provide details on specific information provided in each segment. These details may change from the start of the transaction to the end of the transaction.
+The TC String returned by the CMP API can include (2) segments of information : the core string and the publisher TC segment. The technical specs describing the TC string provide details on specific information provided in each segment. These details may change from the start of the transaction to the end of the transaction.
 
 ## How should I handle multiple signals with different information?<a name="mergesignals"></a>
-Sometimes two or more TC Strings might contain different preferences for different vendors. For example, one String includes consent signals for vendors 1, 2, and 3. Later, the user is asked for consent on vendors 3, 4, and 5, but rejects all three. In this example, the most recent signal received for vendor 3 is that of no consent and should be recorded as such despite previous signals. However, we cannot anticipate and provide guidance for all scenarios. Vendors should update the TC String, where applicable, with details that reflect the intent of the user and meets the requirements of the TCF.
-
-## What happened to Global Scope and Out of Band?<a name="gsoob"></a>
-The TCF Policy previously allowed legal bases in the Framework to be established with global scope, which means a legal basis is not only applicable on the service or group of services (service-specific and group-specific scopes) where it is obtained and managed, but all services implementing global scope preferences. In the context of global scope, TC Strings were stored in a 3rd party cookie associated with the “consensu.org” domain that enabled Consent Management Providers (CMPs) to read the “TC strings from their subdomains <code>[cmp-name].mgr.consensu.org</code> across different services. Deprecation of global-scope support was [announced](https://iabeurope.eu/wp-content/uploads/2021/06/TCF_V-CMP_comms_DeprecationOfGlobalScopeSupportInTCF_220621_IABEurope.pdf) on June 22nd 2021. Alongside the deprecation of global scope, support for Out-of-Band (OOB) - which refers to instances where a legal basis has not been established using the TCF in a global-scope context - was also deprecated. Since Sept 1st 2021, TC strings established with global-scope are considered invalid.
+Sometimes two or more TC Strings might contain different preferences for different vendors. For example, one string includes consent signals for vendors 1, 2, and 3. Later, the user is asked for consent on vendors 3, 4, and 5, but rejects all three. In this example, the most recent signal received for vendor 3 is that of no consent and should be understood as such despite previous signals.
 
 # Publisher guidelines <a name="pub"></a>
 ## What is a Consent Management Platform (CMP) and why do I, as a Publisher, need one?<a name="whatiscmp"></a>
-A Consent Management Platform (CMP) is operated by a controller and is used to manage transparency and consent (TC) preferences signaled by the end user. The CMP installs a user dialogue on the publisher’s digital properties to capture and manage TC information from a user. This installed user dialogue software also surfaces TC information to vendor technologies operating as part of the publisher’s digital property and supply chain. The CMP acts as an intermediary between the publisher, end user, and vendors.
+A Consent Management Platform (CMP) is used to manage transparency and consent (TC) preferences signaled by the end user. The CMP installs a user dialogue on the publisher’s digital properties to capture and manage TC information from a user. This installed user dialogue software also surfaces TC information to vendor technologies operating as part of the publisher’s digital property and supply chain. The CMP acts as an intermediary between the publisher, end user, and vendors.
 
 Please refer to TCF Policy for a complete definition of a CMP. A registered CMP is required if the publisher or website operator wishes to work under the Policies of the TCF.  
 
@@ -152,30 +137,27 @@ The publisher may implement a CMP in one of two ways:
 1.	**Build:** Develop an in-house CMP that meets the technical requirements specified by IAB Europe and register as an official CMP using this form.
 2.	**Outsource:** Rely on  the service of a CMP registered with IAB Europe and listed here as an official CMP. 
 
-## What publisher controls are available? What happened to Pubvendors?<a name="pubvendors"></a>
-The goal of pubvendors.json was to enable publisher control over their vendor relationships and data purposes but was ultimately found to be an incomplete and error-prone solution. 
-
-In v2 of the TC String, a segment of information enables publishers to define restrictions. Another segment defines their vendor relationships in a list of allowed vendors. These publisher controls replace the pubvendors.json solutions and is to be deprecated after a transition phase for v2 implementation.
+## What publisher controls are available?<a name="pubcontrols"></a>
+Starting with v2 of the TC String, a segment of information enables publishers to define restrictions. When a vendor has declared their legal basis for a purpose as flexible, the publisher can change the vendor’s defaut choice. For instance if a vendor declares flexible with default choice legitimate interest, the publisher can restrict that choice to requires consent.
 
 ## The Global Vendor List<a name="gvl"></a>
-Publishers should ask their partners (advertising vendors, DMPs, analytics vendors, etc.) to register on the Global Vendor List (GVL), if not already registered. The Global Vendor List is maintained with current registered vendors here. 
+Publishers can ask their partners (advertising vendors, DMPs, analytics vendors, etc.) to register on the Global Vendor List (GVL), if not already registered. The Global Vendor List is maintained with current registered vendors [here](https://vendor-list.consensu.org/v2/vendor-list.json). 
 
 ## Withdrawal of consent<a name="withdraw"></a>
-Vendors must support the withdrawal of consent. Since consent is transmitted from publisher or CMPs to partners and vendors on each request, the publisher or CMP should provide a mechanism for users to withdraw consent. This mechanism may be as simple as collecting consent at each user session, or providing an option that enables the user to withdraw consent later. The UI for withdrawing consent should be the same as the UI by which consent was given.
+Vendors must support the withdrawal of consent. Since consent choices are transmitted from publisher or CMPs to partners and vendors on each transaction, the publisher or CMP should provide a mechanism for users to withdraw consent. This mechanism may be as simple as providing users with an easily accessible link/setting or a floating icon as to allow users to withdraw their consent as easily as it was to give it.
 
-# Vendor guidelines (DSPs, Agencies, DMPs)<a name="vendor"></a>
+# Vendor guidelines<a name="vendor"></a>
 For vendors or media buyers registered in the Global Vendor List, these guidelines help you understand how to determine whether you have the necessary legal bases to process a user's personal data for the purposes you've disclosed in the GVL, based on the information contained in the TC String.
 
-1.	In order to read or process user data in compliance with the TCF or store and/or access information on a user’s device in compliance with the TCF, vendors must be registered in the Global Vendor List. 
-2.	Vendors should check consent for users from the EEA (EU + Norway + Island + Liechtenstein).
-3.	Vendors should be able to identify traffic that falls under the GDPR.
+1.	In order to read or process user data in compliance with the TCF or store and/or access information on a user’s device in compliance with the TCF, vendors must be registered in the Global Vendor List.
+3.	Vendors should be able to identify traffic that falls under the GDPR territorial scope.
 
-The OpenRTB GDPR Advisory should be used to communicate user consent. Vendors can use the two extension fields, GDPR and CONSENT, in OpenRTB to determine action. 
+The instructions from OpenRTB GDPR Advisory should be used to communicate user consent when using the OpenRTB protocol. Vendors can use the two extension fields, GDPR and CONSENT, in OpenRTB to determine action. 
 		
 ## How do I find the TC String?<a name="findtcstring"></a>
 If an impression is received server side (through openRTB for example), you should read the information from the TC data payload. For openRTB, technical specifications were updated to provide information on where and how the information is passed. For other non-standard server side delivery, clarify with the partner on how the TC data payload is passed.
 
-When the impression is received client side (redirect, prebid, etc.), leverage the CMP to request and read the TC data. This information can be collected whether you are in the top parent page (using the __tcfapi method) or from an iframe (using postMessage method as defined by the CMP API technical specifications).
+When the impression is received client side (redirect, prebid, etc.), the TCF API provided through the CMP should be used to access the TC data object. This information can be collected whether you are in the top parent page (using the __tcfapi method) or from an iframe (using postMessage method as defined by the CMP API technical specifications). Use a callback function passed to the TCF API event listener API (addEventListener) to retrieve the most up to date TC data object.
 
 ## How do I send the TC string?<a name="sendtcstring"></a>
 For any server side call, if using openRTB, the consent payload should be sent according to the openRTB specs.
@@ -209,51 +191,30 @@ After determining the applicable legal basis, vendors must then check:
 Only if both signals are positive for the applicable legal basis in the TC String may the vendor process for that purpose.
 
 ## How to determine if data may be transmitted?<a name="handletcstring"></a>
-According to the policies of the Transparency and Consent Framework, a vendor may choose not to transmit data to another vendor for any reason, but a vendor must not transmit data to another vendor without a justified basis for relying on that vendor’s legal basis for processing the personal data. If a vendor has or obtains personal data and has no legal basis for the access to and processing of that data, the vendor should quickly cease collection and storage of the data and refrain from passing the data on to other parties, even if those parties have a legal basis. To determine if a vendor has at least one legal basis to process a user’s personal data [see "How to determine legal bases from the TC String?"](#detlegalbasis).
+According to the policies of the Transparency and Consent Framework, a vendor may choose not to transmit data to another vendor for any reason, but a vendor must not transmit data to another vendor without a justified basis for relying on that vendor’s legal basis for processing the personal data. If a vendor has or obtains personal data and has no legal basis for the access to and processing of that data, the vendor should cease collection and storage of the data and refrain from passing the data on to other parties, even if those parties have a legal basis. To determine if a vendor has at least one legal basis to process a user’s personal data [see "How to determine legal bases from the TC String?"](#detlegalbasis).
 
-## Agency guidelines<a name="agencyguide"></a>
-In addition to the vendor guidelines, agencies may want to consider the following details: 
-- If you're handling any personal data, register as a vendor in the Global Vendor List. 
-- Become familiar with the capabilities of your DSP partner(s) so that you only work with personal data when you have a legal basis to do so. Some of the following questions may help you get started:
-	- Are your DSPs working with the TCF?
-	- Are your DSPs reading the TC String passed through OpenRTB?
-	- How are your DSP partners communicating transparency and consent and are they passing personal data only when there is a legal basis? How do they track these practices?
+## What if I don’t receive the TC string?<a name="nostring"></a>
+If transparency or consent information is unavailable in situations where TCF applies, you may not be able to process the user's data.
 
-## DSP guidelines<a name="dspguide"></a>
-In addition to vendor guidelines, DSPs should consider the following points:
-- If you're handling any personal data, register as a vendor in the Global Vendor List. 
-- Support ingesting transparency and consent signals on openRTB bid requests. 
-- Decide how to handle bidding based on these signals, ensuring that processing of user data only occurs when there is a legal basis.
-
-## DMP guidelines<a name="dmpguide"></a>
-DMP in this document refers to enterprise software that can be used by publishers, marketers, agencies and third-party vendors to centralize marketing information associated with pseudonymous IDs. To take advantage of the Framework, DMPs should be registered to the Global Vendor List. For simplicity sake, we will assume the same guidelines apply for both buy-side focused and sell-side focused DMPs. While oriented towards different buyers, buy-side and sell-side DMPs centralize this data, enable forecasting and reporting, and often enable syndication to take-action systems (e.g., Publishers, DSPs, DCO vendors, and Site Optimization/Personalization vendors). 
-
-## How does the TC String apply to non-OpenRTB situations?<a name="nonrtb"></a>
-- Many requests for ad serving will include the TC String. 
-- Some requests will be sent to vendors without a TC String, such as: publishers not implementing a CMP, server-initiated server-to-server data transfers such as syndication or CRM onboarding, and consumer opt-outs from centralized privacy pages such as AboutAds.info.
-- When a visitor visits a publisher page with a CMP implemented, the first JavaScript that loads should be the CMP.js library. First time visitors are presented with a UI that offers choices to the user, which are then stored in a TC String. Return visitors need not see the UI again, and any associated TC String may be updated if the user changes any preferences.  
+## What else is there to consider when integrating with the TCF?<a name="whatelse"></a>
 - Tag management containers should integrate CMP code. In addition to enriching ad calls, a CMP should also support calling a third-party tag management container that will handle robust tag logic already implemented on behalf of the publisher. 
-- Syndication for buy-side DMPs centralizes marketing information associated with pseudonymous IDs, which enables marketers to improve their media planning, syndication and cross-vendor reporting. 
+- Syndication for buy-side DMPs centralizes marketing information associated with pseudonymous IDs, which enables marketers to improve their media planning, syndication and cross-vendor reporting.
 	- Syndication of audience segments is often initiated by a marketer ruleset to send information from the DMP to take-action systems (DSP, DCO, Site Optimization, etc.).
-	- For GDPR purposes, the DMP maintains a server-side consent store that maintains the most recent consent state associated with its pseudonymous IDs. This server-side store is also useful for maintaining the audit log of signals received. 
-	- Because the TC String maintains the current consent state for all vendors, the DMP can send only pseudonymous IDs with consent state=1 to recipient vendors.
+	- Because the TC string maintains the current consent state for all vendors, the DMP can send only pseudonymous IDs with consent state=1 to recipient vendors.
 
 # Consent Management Platform (CMP) guidelines<a name="cmp"></a>
 This section outlines implementation guidelines for CMPs to be compliant with the TCF technical specification when collecting, storing and sharing user consent.
 
-Register to be on the CMP list: https://register.consensu.org/. This step is required to be a TCF recognised CMP trusted by vendors receiving the consents that you collect. Upon registration a CMP is assigned an ID, which is passed with each request. Since September 1st 2021, new registering CMPs are no longer granted access to the “consensu.org” domain. CMPs who have been registered with the TCF before September 1st 2021 can continue to host their tags at <code>https://[cmpname].mgr.consensu.org/</code>. 
+Register to be on the CMP list: https://register.consensu.org/. This step is required to be a TCF recognised CMP trusted by vendors receiving the consents that you collect. Upon registration a CMP is assigned an ID, which is passed with each request. Since September 1st 2021, new registering CMPs are no longer granted access to the “consensu.org” domain. Starting from July 10th 2023, CMPs who have been registered with the TCF before September 1st 2021 will no longer be able to host their tags at https://[cmpname].mgr.consensu.org/.
 
-Note: it is the intention of the managing organisation at some point in the future to retire "consensu.org".
-
-
-## 1. Collecting consent from users<a name="collectconsent"></a>
+## Collecting consent from users<a name="collectconsent"></a>
 The TCF defines a set of common purposes and features that vendors can act on. Vendors are responsible for providing up-to-date information on the purposes they support and the legal basis under which they wish to operate these purposes. This information is captured in the  Global Vendor List (GVL). 
 
-For a given publisher, a CMP must (at least) collect the user consent for all purposes and vendors declared by the publisher. With the publisher agreement, a CMP can also collect consent for all purposes and vendors in the GVL.
+For a given publisher, a CMP must collect the user consent for all purposes and vendors declared/chosen by the publisher.
 
 A range of requirements on how consent must be presented, collected and stored can be found in the TCF policy document.
 
-## 2. Sharing consent with vendors<a name="shareconsent"></a>
+## Sharing consent with vendors<a name="shareconsent"></a>
 The TCF defines standard APIs and formats for communicating between CMPs collecting consent from end users and vendors embedded on a website or in a mobile application.
 This API provides a unified interface for seamless interaction between the parties in the advertising industry.
 
@@ -262,21 +223,19 @@ As a CMP, you will need to:
 - Generate an encoded data string, the TC String, containing the set of preferences expressed by the user
 - Share the TC String with vendors through the available APIs.
 
-## 3. Storing Consent<a name="storeconsent"></a>
+## Storing Consent<a name="storeconsent"></a>
 In version 2 of the TCF Specifications, the storage mechanism used for service-specific and group-specific TC Strings is up to a CMP, including any non-cookie storage mechanism.
 
 For long-term storage, the following methods are common across CMPs:
 
 Method | Pros | Cons
 ------------ | ------------- | -------------
-Cookies | Easy to use and cheap. Fast and provide a good user experience. | Short-lived. Cannot be used as proof of consent. Third-party cookies might be blocked by browsers so web-wide consent can be hard to implement
+Cookies | Easy to use and cheap. Fast and provide a good user experience. | Short-lived. First-party cookies might be regularly deleted by browsers
 Server-side storage | Long-lived. Can be used as proof of consent | Can be slow (use cookies/local storage as client-side cache). Requires a long-term ID (cookie ID or email or similar user ID)
-Mobile: internal data storage / shared preferences | Easy to use and cheap. Fast and provide a good user experience | Cannot be used as proof of consent. Cannot be shared across apps so device-wide consent can be hard to achieve
+Mobile: internal data storage / shared preferences | Easy to use and cheap. Fast and provide a good user experience | Cannot be shared across apps so group-specific consent can be hard to achieve
 
-You’ll usually want to go with a combination of server-side storage – for being able to store consent for a long time and share it across websites/apps – and a client-side storage like cookies or shared preferences – for a local fast-to-access cache.
-
-## 4. Withdrawal of consent and other non-TCF policy <a name="withdrawconsent"></a>
-Signals sent through the IAB Europe framework should only indicate what the user status is at the time of the signal creation and nothing else. While the CMP should also enable users to withdraw consent, the minimum requirement is to record the user's preference at the time the signal is created. Certain GDPR policy, such as portability and the right to be forgotten, is not covered in the IAB Europe TCF. CMPs and vendors should address other GDPR rights outside the TCF separately and on their own.
+## Other GDPR rights <a name="otherrights"></a>
+Certain GDPR rights, such as portability and the right to be forgotten, are not covered in the IAB Europe TCF. CMPs, publishers and vendors should address other GDPR rights outside the TCF separately and on their own.
 
 ## 5. Encoding publisher restrictions <a name="pubrestrenc"></a>
 In order to reduce the size of the TC string, CMPs are advised to store/provide publisher restrictions only when necessary to reflect the publisher's choice to restrict a vendor's processing of personal data. In terms of reflecting a publisher’s choice:
@@ -293,33 +252,20 @@ Note that the above does not preclude the use of efficient encoding/decoding sch
 ## 6. CMP interface requirements<a name="cmpreq"></a>
 Please refer to the policies for the minimal information / functionality that needs to be shown on the first screen of the UI and the information that must be present on second/additional layers of the UI.
 
-# How do vendors outside the RTB bidstream query a CMP?<a name="outsidertb"></a>
-At a high level, all vendors need to query the CMP on the page to get access to consent information in the TC String, parse the consent data in the String, and gate usage of user data based on user consent. This lookup needs to be executed as close as possible to using the user data so that the latest value of consent is used.
-
-1. **GVL registration:** Before you can work with a CMP, you need to be registered as a vendor. You can sign up to be added to the GVL on IAB Europe's registration site. 
-2. **Query CMP:** Once added, you can query the CMP for consent information. Details about how to query the CMP are provided in the documentation for CMP API v2. Initiate consent query before applying workflow to reduce latency. 
-3. **Determine data usage:** Parse the TC String for details on whether GDPR applies and the user's consent status for allowing the use of user's data. This consent can differ by purpose and by vendor.
-
-
-## What if I don’t receive the TC string?
-Unfortunately, if transparency or consent information is unavailable, you may not be able to process the user's data. 
-
-## Does the policy make a difference between functional and marketing cookies? Do I need consent for functional cookies?
-You may or may not depending on whether the scenario is covered by special features or special purposes. Review the policy documentation to learn more.
-
 # Other Frequently Asked Questions<a name="otherfaq"></a>
 ## Are cookies required for working with the CMP API?<a name="cookiesrequired"></a>
-No, in version 2 of the TCF Specifications, the storage mechanism used for service-specific and group-specific TC Strings is up to a CMP, including any non-cookie storage mechanism.
+No, in version 2 and higher of the TCF Specifications, the storage mechanism used for service-specific and group-specific TC strings is up to a CMP, including any non-cookie storage mechanism.
 
 For further explanations, please go to the section [Storing Consent](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/TCF-Implementation-Guidelines.md#3-storing-consent) above.
 
 ## Can I also use the API for CCPA or other laws?<a name="ccpa"></a>
-At this time, the IAB Europe Transparency and Consent Framework is designed for compliance with GDPR. The CMP API was designed to only support a special use case of the GDPR, which involves the use of user data in the context of digital advertising. Consult your local IAB or the IAB Tech Lab to learn more about other ongoing projects for privacy tool development.
+At this time, the IAB Europe Transparency and Consent Framework is designed for compliance with GDPR. The CMP API was designed to only support a special use case of the GDPR, which involves the use of user data in the context of digital advertising or content. Consult your local IAB or the IAB Tech Lab to learn more about other ongoing projects for privacy tool development such as the Global Privacy Platform (GPP).
+
 ## Related resources<a name="resources"></a>
 A v2 consent string encoder/decoder can be found here: https://iabtcf.com/#/ as well as links to further implementation libraries.
 
-### Will these FAQ be updated? <a name="faqupdates"></a>
-Yes, these guidelines will be updated as questions arise. A wiki with more dynamic content has been proposed, but timelines have not yet been determined.
+## Will these FAQ be updated?<a name="faqupdates"></a>
+Yes, these guidelines will be updated as questions arise.
 
-### How can I learn more?<a name="learnmore"></a>
-Join the working group, or stay tuned for build out of a wiki to support dynamic responses to questions from implementers.
+## How can I learn more?<a name="learnmore"></a>
+Visit our TCF web page at https://iabeurope.eu/tcf-2-0/ and join the working group.

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -11,7 +11,7 @@
 </tr>
 </table>
 
-This document provides technical implementation guidelines related to the [IAB Europe Transparency and Consent Framework (TCF) v2.1 technical specs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework). The IAB Tech Lab GDPR Technical Working Group has collaborated on the following implementation guidelines, and will continue to produce resources supporting industry adoption of the Framework. The intended audience of this document includes product and engineering teams who are building technology based on this framework, and who are looking for guidance on implementation strategies such as questions to ask your platform partners or avoiding common pitfalls.
+This document provides technical implementation guidelines related to the [IAB Europe Transparency and Consent Framework (TCF) v2.2 technical specs](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework). The IAB Tech Lab GDPR Technical Working Group has collaborated on the following implementation guidelines, and will continue to produce resources supporting industry adoption of the Framework. The intended audience of this document includes product and engineering teams who are building technology based on this framework, and who are looking for guidance on implementation strategies such as questions to ask your platform partners or avoiding common pitfalls.
 
 Policy FAQ, webinars, and other resources are available at 
 [https://iabeurope.eu/tcf-2-0/](https://iabeurope.eu/tcf-2-0/)
@@ -20,6 +20,7 @@ Policy FAQ, webinars, and other resources are available at
 ### [Introduction to the TCF](#Intro)<br>
 ### [Common Questions](#commonquestions)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Do I need to read the Policy?](#needpolicy)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.2?](#changesV2_2)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.1?](#changesV2_1)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2?](#changesV2)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Within the Transparency and Consent String (TC String)](#changetcstring)<br>
@@ -59,7 +60,7 @@ The Transparency and Consent Framework (TCF) was created to help all parties who
 
 It allows publishers and website operators to communicate to vendors, in a standardized way, what preferences users have expressed when it comes to their personal data. A vendor is a company that participates in the delivery of digital advertising within a publisher’s website, app, or other digital content, that either accesses an end user’s device or browser or processes personal data about end users visiting the publishers content.
 
-The TCF was first introduced in April 2018. This document refers to version 2.1 of the TCF, announced in May 2023, which introduces significant changes and is not backward-compatible with the earlier versions.
+The TCF was first introduced in April 2018. This document refers to version 2.2 of the TCF, announced in May 2023, which introduces significant changes and is not backward-compatible with the earlier versions.
 
 The communication between publishers and vendors must pass through a Consent Management Platform (CMP). A CMP can be operated by anyone, as long as the entity that operates it has completed registration and is approved by IAB Europe. A list of all approved CMPs is available [here](https://iabeurope.eu/cmp-list/).
 
@@ -85,13 +86,16 @@ Yes, the technical specifications for the TC String and CMP API were developed t
 
 If you have not yet read tech specs or policy, you can access these documents here: 
 - [IAB Europe Transparency and Consent Framework Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/)
-- [Transparency and Consent String, Version 2.1](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
-- [Consent Management Platform API, Version 2.1](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
+- [Transparency and Consent String, Version 2.2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md)
+- [Consent Management Platform API, Version 2.2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
 
 All definitions in the implementation guidelines should reflect definitions provided in the Policy. 
 
+## What changed in v2.2?<a name="changesV2_2"></a>
+The TCF v2.2 update further strengthens the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls, deprecation of the __tcfapi command "getTCData" and introducing a more robust vendor compliance program.
+
 ## What changed in v2.1?<a name="changesV2_1"></a>
-The TCF v2.1 update further strengthens the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls, deprecation of the __tcfapi command "getTCData" and introducing a more robust vendor compliance program.
+Added the Device Storage Access & Disclosure to address the Planet 49 ruling.
 
 ## What changed in v2?<a name="changesV2"></a>
 Version 2 of the policy and technical specification marked significant updates to better support GDPR legislation and enhance the user experience, while remaining flexible to account for unique scenarios within the framework.

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -39,6 +39,7 @@ Policy FAQ, webinars, and other resources are available at
 &nbsp;&nbsp;&nbsp;&nbsp;**[How to determine legal bases from the TC String?](#detlegalbasis)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[How to determine if data may be transmitted?](#handletcstring)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What if I don’t receive the TC string?](#nostring)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[How do I determine which Global Vendor List to use?](#choosegvl)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What else is there to consider when integrating with the TCF?](#whatelse)**<br>
 ### [Consent Management Platform (CMP) guidelines](#cmp)
 &nbsp;&nbsp;&nbsp;&nbsp;**[Collecting consent from users](#collectconsent)**<br>
@@ -199,6 +200,9 @@ According to the policies of the Transparency and Consent Framework, a vendor ma
 
 ## What if I don’t receive the TC string?<a name="nostring"></a>
 If transparency or consent information is unavailable in situations where TCF applies, you may not be able to process the user's data.
+
+## How do I determine which Global Vendor List to use?<a name="choosegvl"></a>
+With TCF v2.2 the global vendor list specification version will be set to 3. We will restart the vendor list version at 1 and increment for each update. TCF 2.2 supports the TCF policy version 4 or higher. The global vendor list (spec version 3) has the policy version encoded accordingly to 4 or higher. The TC string corresponding to TCF 2.2 will also have the policy version set to 4. Vendors need to read the policy version in the TCString to determine which global vendor list to use. (A policy version of 4 or higher requires the global vendor list with gvlSpecificationVersion set to 3.)
 
 ## What else is there to consider when integrating with the TCF?<a name="whatelse"></a>
 - Tag management containers should integrate CMP code. In addition to enriching ad calls, a CMP should also support calling a third-party tag management container that will handle robust tag logic already implemented on behalf of the publisher. 

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -143,7 +143,7 @@ The publisher may implement a CMP in one of two ways:
 2.	**Outsource:** Rely on  the service of a CMP registered with IAB Europe and listed here as an official CMP. 
 
 ## What publisher controls are available?<a name="pubcontrols"></a>
-Starting with v2 of the TC String, a segment of information enables publishers to define restrictions. When a vendor has declared their legal basis for a purpose as flexible, the publisher can change the vendor’s defaut choice. For instance if a vendor declares flexible with default choice legitimate interest, the publisher can restrict that choice to requires consent.
+Starting with v2 of the TC String, a segment of information enables publishers to define restrictions. When a vendor has declared their legal basis for a purpose as flexible, the publisher can change the vendor’s default choice. For instance if a vendor declares flexible with default choice legitimate interest, the publisher can restrict that choice to requires consent.
 
 ## The Global Vendor List<a name="gvl"></a>
 Publishers can ask their partners (advertising vendors, DMPs, analytics vendors, etc.) to register on the Global Vendor List (GVL), if not already registered. The Global Vendor List is maintained with current registered vendors [here](https://vendor-list.consensu.org/v2/vendor-list.json). 


### PR DESCRIPTION
Update the files Tech Lab - Consent string and vendor list formats v2.md and Tech Lab - CMP API v2.md based on the latest policy changes and tech specs. In detail: Update several sections to introduced retention periods for all purposes, removal of legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls. Removed references to v1.1 where that information was no longer required.
Update the GVL list section accordingly: Updated the API specification: Deprecated the API getTCData as well as some other small tweaks. Removed references to v1.1 where that information was no longer required.