### PR TITLE
Update IAB Tech Lab - CMP API v2.md

### DIFF
--- a/TCFv2/IAB Tech Lab - CMP API v2.md
+++ b/TCFv2/IAB Tech Lab - CMP API v2.md
@@ -751,7 +751,7 @@ The TC data values can be retrieved from the application Shared Preferences by k
 Context mContext = getApplicationContext();
 SharedPreferences mPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
 String consentString = mPreferences.getString("IABTCF_TCString", "");
-int gdprApplies = mPreferences.getInt("IABTCF_gdprApplies", "");
+int gdprApplies = mPreferences.getInt("IABTCF_gdprApplies", 0);
 ```
 A callback can be registered to update settings when a preference is changed using the `registerOnSharedPreferenceChangeListener` method for the `android.content.SharedPreferences` class.
 


### PR DESCRIPTION
Default value for getting int in mPreferences.getInt() cannot be String, it is compilation error. In your case empty string "". It should be Integer and need to be set to 0.