### PR TITLE
Fix probably typo on IAB Tech Lab - Consent string and vendor list formats v2.md

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -413,7 +413,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
       <td>Created</td>
       <td>36 bits</td>
       <td>
-        Epoch time format when TC String was last updated (must be updated any time a value is changed)
+        Epoch time format when TC String was created
       </td>
       <td rowspan="2">
        To create a timestamp in JavaScript: <code>Math.round(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())/100)</code>. Also, the timestamp must be based in UTC time in order to get a consistent decisecond value across the time zones.


### PR DESCRIPTION
I believe there is a copy paste error on the created field, it has the same description as last updated