### PR TITLE
Updates to reflect the change in the disclosed vendors section.

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -64,6 +64,7 @@
 
 | Date | Version | Comments |
 | :-- | :-- | :-- |
+| Apr 2025 | 2.3 | Resolve the LI ambiguity by repurposing and making the ‘Disclosed Vendors’ section a mandatory section of the TC string.
 | Feb 2024 | 2.2 | Deprecated the gdpr_pd macro, and added the field 'environments' to the CMP JSON. |
 | May 2023 | 2.2 | Update to further strengthen the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls and introducing a more robust vendor compliance program. |
 | June 2022 | 2.1 | Update of the <b>Global Vendor List JSON Object</b> example regarding the filename in `deviceStorageDisclosureUrl` |
@@ -1018,7 +1019,7 @@ CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEg
 
 #### Disclosed Vendors
 
-The _**DisclosedVendors**_ is an optional TC String segment that records which vendors have been disclosed to a given user by a CMP. It may be used by a CMP while [storing](#how-should-a-transparency--consent-string-be-stored) TC Strings, but must not be included in the TC String when returned by the CMP API.
+The _**DisclosedVendors**_ is the TC String segment that records which vendors have been disclosed to a given user by a CMP. This is a mandatory segment.
 
 
 <table>

--- a/TCFv2/TCF-Implementation-Guidelines.md
+++ b/TCFv2/TCF-Implementation-Guidelines.md
@@ -19,6 +19,7 @@ Policy FAQ, webinars, and other resources are available at
 ### [Introduction to the TCF](#Intro)<br>
 ### [Common Questions](#commonquestions)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[Do I need to read the Policy?](#needpolicy)**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.3?](#changesV2_3)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.2?](#changesV2_2)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2.1?](#changesV2_1)**<br>
 &nbsp;&nbsp;&nbsp;&nbsp;**[What changed in v2?](#changesV2)**<br>
@@ -90,6 +91,9 @@ If you have not yet read tech specs or policy, you can access these documents he
 - [Consent Management Platform API, Version 2.2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
 
 All definitions in the implementation guidelines should reflect definitions provided in the Policy. 
+
+## What changed in v2.3?<a name="changesV2_3"></a>
+The TCF v2.3 update introduces a change to resolve the ambiguity for disclosed vendors that neither declare consent nor legitimate interest. It makes the Disclosed Vendor segment mandatory for CMPs to declare the vendors they have disclosed to the user.
 
 ## What changed in v2.2?<a name="changesV2_2"></a>
 The TCF v2.2 update further strengthens the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls, deprecation of the __tcfapi command "getTCData" and introducing a more robust vendor compliance program.


### PR DESCRIPTION
Updated based on the decision made by the TCF FSWG to repurpose the disclosed vendors section to indicate the disclosed vendors and making this section a mandatory section in the TCString.  (see https://docs.google.com/document/d/1evetwMlA_TCJ-GJp3fOqm1k_4W6l6qXA/edit).