### PR TITLE
add missing close to code block

### DIFF
--- a/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
+++ b/TCFv2/IAB Tech Lab - Consent string and vendor list formats v2.md
@@ -375,6 +375,7 @@ The _**[Core String](#the-core-string)**_ is always required and comes first and
 
 ```
 CQSbk4AQSbk4ANwAAAENAwCgAAAAAAAAAAYgACPAAAAA.IDKQA4AAgAKAGQAygAAA.YAAAAAAAAAAA
+```
 
 The _**[Core String](#the-core-string)**_ comes first and includes all the details required for communicating basic vendor transparency and consent.
 


### PR DESCRIPTION
See https://github.com/Gregofi/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#a-tc-string-must-contain-a-core-tc-string-and-the-disclosed-vendors-segment-it-may-optionally-contain-a-publisher-tc-segment, the page is broken because TCString code block is not closed. Maybe from some merge error in db2ca6cc92af821ba7f910a0f8928cf1eadd340d?